### PR TITLE
Add workflow and workflow activity tree elements to wi-extension

### DIFF
--- a/wi/wi-extension/package.json
+++ b/wi/wi-extension/package.json
@@ -317,6 +317,18 @@
         "title": "Add Custom Connector",
         "icon": "$(add)",
         "category": "WSO2 Integrator"
+      },
+      {
+        "command": "BI.project-explorer.add-workflow",
+        "title": "Add Workflow",
+        "icon": "$(add)",
+        "category": "WSO2 Integrator"
+      },
+      {
+        "command": "BI.project-explorer.add-workflow-activity",
+        "title": "Add Workflow Activity",
+        "icon": "$(add)",
+        "category": "WSO2 Integrator"
       }
     ],
     "menus": {
@@ -379,6 +391,14 @@
         },
         {
           "command": "BI.project-explorer.add-custom-connector",
+          "when": "false"
+        },
+        {
+          "command": "BI.project-explorer.add-workflow",
+          "when": "false"
+        },
+        {
+          "command": "BI.project-explorer.add-workflow-activity",
           "when": "false"
         }
       ],

--- a/wi/wi-extension/package.json
+++ b/wi/wi-extension/package.json
@@ -400,7 +400,7 @@
         },
         {
           "command": "BI.project-explorer.delete",
-          "when": "view == wso2-integrator.explorer && viewItem == CONNECTION || viewItem == SERVICE || viewItem == FUNCTION || viewItem == AUTOMATION || viewItem == TYPE || viewItem == CONFIGURABLE || viewItem == DATA_MAPPER || viewItem == NP_FUNCTION || viewItem == localConnector",
+          "when": "view == wso2-integrator.explorer && viewItem == CONNECTION || viewItem == SERVICE || viewItem == FUNCTION || viewItem == AUTOMATION || viewItem == TYPE || viewItem == CONFIGURABLE || viewItem == DATA_MAPPER || viewItem == NP_FUNCTION || viewItem == localConnector || viewItem == WORKFLOW || viewItem == ACTIVITY",
           "group": "inline"
         },
         {
@@ -446,6 +446,16 @@
         {
           "command": "BI.project-explorer.add-custom-connector",
           "when": "view == wso2-integrator.explorer && viewItem == localConnectors",
+          "group": "inline"
+        },
+        {
+          "command": "BI.project-explorer.add-workflow",
+          "when": "view == wso2-integrator.explorer && viewItem == workflows",
+          "group": "inline"
+        },
+        {
+          "command": "BI.project-explorer.add-workflow-activity",
+          "when": "view == wso2-integrator.explorer && viewItem == workflowActivities",
           "group": "inline"
         }
       ],

--- a/wi/wi-extension/src/bi/project-explorer/project-explorer-provider.ts
+++ b/wi/wi-extension/src/bi/project-explorer/project-explorer-provider.ts
@@ -430,35 +430,31 @@ function getEntriesBI(project: ProjectStructure): ProjectExplorerEntry[] {
 
     // ---------- Workflows ----------
     const workflowChildren = getComponents(project.directoryMap[DIRECTORY_MAP.WORKFLOW] ?? [], DIRECTORY_MAP.WORKFLOW, projectPath);
-    if (workflowChildren.length > 0) {
-        const workflows = new ProjectExplorerEntry(
-            'Workflows',
-            vscode.TreeItemCollapsibleState.Expanded,
-            null,
-            'workflow',
-            false
-        );
-        workflows.resourceUri = Uri.parse(`bi-category:${projectPath}`);
-        workflows.contextValue = 'workflows';
-        workflows.children = workflowChildren;
-        entries.push(workflows);
-    }
+    const workflows = new ProjectExplorerEntry(
+        'Workflows',
+        workflowChildren.length > 0 ? vscode.TreeItemCollapsibleState.Expanded : vscode.TreeItemCollapsibleState.Collapsed,
+        null,
+        'workflow',
+        false
+    );
+    workflows.resourceUri = Uri.parse(`bi-category:${projectPath}`);
+    workflows.contextValue = 'workflows';
+    workflows.children = workflowChildren;
+    entries.push(workflows);
 
     // ---------- Workflow Activities ----------
     const activityChildren = getComponents(project.directoryMap[DIRECTORY_MAP.ACTIVITY] ?? [], DIRECTORY_MAP.ACTIVITY, projectPath);
-    if (activityChildren.length > 0) {
-        const workflowActivities = new ProjectExplorerEntry(
-            'Workflow Activities',
-            vscode.TreeItemCollapsibleState.Expanded,
-            null,
-            'task',
-            false
-        );
-        workflowActivities.resourceUri = Uri.parse(`bi-category:${projectPath}`);
-        workflowActivities.contextValue = 'workflowActivities';
-        workflowActivities.children = activityChildren;
-        entries.push(workflowActivities);
-    }
+    const workflowActivities = new ProjectExplorerEntry(
+        'Workflow Activities',
+        activityChildren.length > 0 ? vscode.TreeItemCollapsibleState.Expanded : vscode.TreeItemCollapsibleState.Collapsed,
+        null,
+        'task',
+        false
+    );
+    workflowActivities.resourceUri = Uri.parse(`bi-category:${projectPath}`);
+    workflowActivities.contextValue = 'workflowActivities';
+    workflowActivities.children = activityChildren;
+    entries.push(workflowActivities);
 
     // ---------- Configurations ----------
     const configs = new ProjectExplorerEntry(

--- a/wi/wi-extension/src/bi/types.ts
+++ b/wi/wi-extension/src/bi/types.ts
@@ -48,6 +48,8 @@ export const BI_COMMANDS = {
     SHOW_OVERVIEW: 'BI.project-explorer.overview',
     ADD_DATA_MAPPER: 'BI.project-explorer.add-data-mapper',
     ADD_NATURAL_FUNCTION: 'BI.project-explorer.add-natural-function',
+    ADD_WORKFLOW: 'BI.project-explorer.add-workflow',
+    ADD_WORKFLOW_ACTIVITY: 'BI.project-explorer.add-workflow-activity',
     NOTIFY_PROJECT_EXPLORER: 'BI.project-explorer.notify',
 };
 


### PR DESCRIPTION
## Summary

Related Issue: https://github.com/wso2/product-integrator/issues/678

- Add Workflows and Workflow Activities sections to the project explorer tree view in wi-extension
- Update `wi/wi-extension/package.json` with `BI.project-explorer.add-workflow` and `BI.project-explorer.add-workflow-activity` commands and their menu items
- Update `BI.project-explorer.delete` menu condition to include `WORKFLOW` and `ACTIVITY` context values
- Update `external/wso2-vscode-extensions` submodule with:
  - `WORKFLOW` and `ACTIVITY` added to `DIRECTORY_MAP` enum in ballerina-core
  - `ADD_WORKFLOW` and `ADD_WORKFLOW_ACTIVITY` added to `BI_COMMANDS`
  - Workflow and Workflow Activities tree sections in bi-extension project explorer provider
  - Dark/light SVG assets for workflow icons

https://github.com/user-attachments/assets/5940ee47-ad54-4949-bbe7-551fae7b3963

## Test plan

- [ ] Verify Workflows section appears in the project explorer tree view
- [ ] Verify Workflow Activities section appears in the project explorer tree view
- [ ] Verify add (+) button appears on Workflows tree item
- [ ] Verify add (+) button appears on Workflow Activities tree item
- [ ] Verify delete works on individual WORKFLOW and ACTIVITY items

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project Explorer now always shows "Workflows" and "Workflow Activities" nodes (collapsed when empty).
  * Added inline context-menu commands to create workflows and workflow activities.
  * Extended the delete option to support workflows and workflow activities.

* **Chores**
  * Updated an external extension reference to a newer revision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->