### PR TITLE
Remove workflow and workflow activities from wi-extension tree view (5.0.x)

### DIFF
--- a/wi/wi-extension/assets/dark-workflow.svg
+++ b/wi/wi-extension/assets/dark-workflow.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><g fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><rect width="8" height="8" x="3" y="3" rx="2"/><path d="M7 11v4a2 2 0 0 0 2 2h4"/><rect width="8" height="8" x="13" y="13" rx="2"/></g></svg>

--- a/wi/wi-extension/assets/light-workflow.svg
+++ b/wi/wi-extension/assets/light-workflow.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><rect width="8" height="8" x="3" y="3" rx="2"/><path d="M7 11v4a2 2 0 0 0 2 2h4"/><rect width="8" height="8" x="13" y="13" rx="2"/></g></svg>

--- a/wi/wi-extension/package.json
+++ b/wi/wi-extension/package.json
@@ -317,18 +317,6 @@
         "title": "Add Custom Connector",
         "icon": "$(add)",
         "category": "WSO2 Integrator"
-      },
-      {
-        "command": "BI.project-explorer.add-workflow",
-        "title": "Add Workflow",
-        "icon": "$(add)",
-        "category": "WSO2 Integrator"
-      },
-      {
-        "command": "BI.project-explorer.add-workflow-activity",
-        "title": "Add Workflow Activity",
-        "icon": "$(add)",
-        "category": "WSO2 Integrator"
       }
     ],
     "menus": {
@@ -392,14 +380,6 @@
         {
           "command": "BI.project-explorer.add-custom-connector",
           "when": "false"
-        },
-        {
-          "command": "BI.project-explorer.add-workflow",
-          "when": "false"
-        },
-        {
-          "command": "BI.project-explorer.add-workflow-activity",
-          "when": "false"
         }
       ],
       "view/item/context": [
@@ -420,7 +400,7 @@
         },
         {
           "command": "BI.project-explorer.delete",
-          "when": "view == wso2-integrator.explorer && viewItem == CONNECTION || viewItem == SERVICE || viewItem == FUNCTION || viewItem == AUTOMATION || viewItem == TYPE || viewItem == CONFIGURABLE || viewItem == DATA_MAPPER || viewItem == NP_FUNCTION || viewItem == localConnector || viewItem == WORKFLOW || viewItem == ACTIVITY",
+          "when": "view == wso2-integrator.explorer && viewItem == CONNECTION || viewItem == SERVICE || viewItem == FUNCTION || viewItem == AUTOMATION || viewItem == TYPE || viewItem == CONFIGURABLE || viewItem == DATA_MAPPER || viewItem == NP_FUNCTION || viewItem == localConnector",
           "group": "inline"
         },
         {
@@ -466,16 +446,6 @@
         {
           "command": "BI.project-explorer.add-custom-connector",
           "when": "view == wso2-integrator.explorer && viewItem == localConnectors",
-          "group": "inline"
-        },
-        {
-          "command": "BI.project-explorer.add-workflow",
-          "when": "view == wso2-integrator.explorer && viewItem == workflows",
-          "group": "inline"
-        },
-        {
-          "command": "BI.project-explorer.add-workflow-activity",
-          "when": "view == wso2-integrator.explorer && viewItem == workflowActivities",
           "group": "inline"
         }
       ],

--- a/wi/wi-extension/src/bi/project-explorer/project-explorer-provider.ts
+++ b/wi/wi-extension/src/bi/project-explorer/project-explorer-provider.ts
@@ -353,20 +353,20 @@ function getEntriesBI(project: ProjectStructure): ProjectExplorerEntry[] {
 
     // ---------- Listeners ----------
     if (!isLibrary) {
-        const listenerChildren = getComponents(project.directoryMap[DIRECTORY_MAP.LISTENER], DIRECTORY_MAP.LISTENER, projectPath);
-        if (listenerChildren.length > 0) {
-            const listeners = new ProjectExplorerEntry(
-                'Listeners',
-                vscode.TreeItemCollapsibleState.Expanded,
-                null,
-                'radio',
-                false
-            );
-            listeners.resourceUri = Uri.parse(`bi-category:${projectPath}`);
-            listeners.contextValue = 'listeners';
-            listeners.children = listenerChildren;
-            entries.push(listeners);
+        const listeners = new ProjectExplorerEntry(
+            'Listeners',
+            vscode.TreeItemCollapsibleState.Expanded,
+            null,
+            'radio',
+            false
+        );
+        listeners.resourceUri = Uri.parse(`bi-category:${projectPath}`);
+        listeners.contextValue = 'listeners';
+        listeners.children = getComponents(project.directoryMap[DIRECTORY_MAP.LISTENER], DIRECTORY_MAP.LISTENER, projectPath);
+        if (listeners.children.length > 0) {
+            listeners.collapsibleState = vscode.TreeItemCollapsibleState.Expanded;
         }
+        entries.push(listeners);
     }
 
     // ---------- Connections ----------
@@ -433,34 +433,6 @@ function getEntriesBI(project: ProjectStructure): ProjectExplorerEntry[] {
     }
     entries.push(dataMappers);
 
-    // ---------- Workflows ----------
-    const workflowChildren = getComponents(project.directoryMap[DIRECTORY_MAP.WORKFLOW] ?? [], DIRECTORY_MAP.WORKFLOW, projectPath);
-    const workflows = new ProjectExplorerEntry(
-        'Workflows',
-        workflowChildren.length > 0 ? vscode.TreeItemCollapsibleState.Expanded : vscode.TreeItemCollapsibleState.Collapsed,
-        null,
-        'workflow',
-        false
-    );
-    workflows.resourceUri = Uri.parse(`bi-category:${projectPath}`);
-    workflows.contextValue = 'workflows';
-    workflows.children = workflowChildren;
-    entries.push(workflows);
-
-    // ---------- Workflow Activities ----------
-    const activityChildren = getComponents(project.directoryMap[DIRECTORY_MAP.ACTIVITY] ?? [], DIRECTORY_MAP.ACTIVITY, projectPath);
-    const workflowActivities = new ProjectExplorerEntry(
-        'Workflow Activities',
-        activityChildren.length > 0 ? vscode.TreeItemCollapsibleState.Expanded : vscode.TreeItemCollapsibleState.Collapsed,
-        null,
-        'task',
-        false
-    );
-    workflowActivities.resourceUri = Uri.parse(`bi-category:${projectPath}`);
-    workflowActivities.contextValue = 'workflowActivities';
-    workflowActivities.children = activityChildren;
-    entries.push(workflowActivities);
-
     // ---------- Configurations ----------
     const configs = new ProjectExplorerEntry(
         'Configurations',
@@ -508,16 +480,11 @@ function getComponents(
         if (comp.type !== itemType) {
             continue;
         }
-        const entryIcon = itemType === DIRECTORY_MAP.WORKFLOW
-            ? 'workflow'
-            : itemType === DIRECTORY_MAP.ACTIVITY
-                ? 'task'
-                : comp.icon;
         const fileEntry = new ProjectExplorerEntry(
             comp.name,
             vscode.TreeItemCollapsibleState.None,
             comp.path,
-            entryIcon,
+            comp.icon,
             false,
             comp.position
         );

--- a/wi/wi-extension/src/bi/types.ts
+++ b/wi/wi-extension/src/bi/types.ts
@@ -48,8 +48,6 @@ export const BI_COMMANDS = {
     SHOW_OVERVIEW: 'BI.project-explorer.overview',
     ADD_DATA_MAPPER: 'BI.project-explorer.add-data-mapper',
     ADD_NATURAL_FUNCTION: 'BI.project-explorer.add-natural-function',
-    ADD_WORKFLOW: 'BI.project-explorer.add-workflow',
-    ADD_WORKFLOW_ACTIVITY: 'BI.project-explorer.add-workflow-activity',
     NOTIFY_PROJECT_EXPLORER: 'BI.project-explorer.notify',
 };
 
@@ -71,8 +69,6 @@ export enum DIRECTORY_MAP {
     CONNECTOR = 'CONNECTOR',
     RESOURCE = 'RESOURCE',
     REMOTE = 'REMOTE',
-    WORKFLOW = 'WORKFLOW',
-    ACTIVITY = 'ACTIVITY',
 }
 
 export enum MACHINE_VIEW {


### PR DESCRIPTION
## Summary

Removes the workflow and workflow activity tree elements from the 5.0.x branch, as these changes have been moved to the main branch.

Related Issue: https://github.com/wso2/product-integrator/issues/678

<img width="1840" height="1162" alt="Screenshot 2026-04-09 at 09 52 33" src="https://github.com/user-attachments/assets/5d673c45-8394-4f1a-bb2d-a77621c4027f" />


Reverts the following commits:
- `f7a7f92` Add workflow and workflow activity commands to project explorer
- `3c5739e` Add SVG assets for dark and light workflow icons; enhance project explorer with workflows and activities

**Changes reverted:**
- Removed `dark-workflow.svg` and `light-workflow.svg` assets from wi-extension
- Removed `BI.project-explorer.add-workflow` and `BI.project-explorer.add-workflow-activity` commands from `package.json`
- Removed Workflows and Workflow Activities tree sections from project explorer provider
- Removed `WORKFLOW` and `ACTIVITY` from `DIRECTORY_MAP` enum and `BI_COMMANDS` in `types.ts`

## Test plan

- [ ] Verify Workflows and Workflow Activities sections no longer appear in the 5.0.x project explorer tree view

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed "Listeners" section visibility in the project explorer to always display when applicable.

* **Chores**
  * Removed workflow and workflow activity creation commands from the project explorer.
  * Removed workflow and activity deletion options from context menus.
  * Cleaned up project explorer menu configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->