### PR TITLE
Hide unsupported BI samples from Browse Samples

### DIFF
--- a/wi/wi-extension/src/ws-managers/main/ws-manager.ts
+++ b/wi/wi-extension/src/ws-managers/main/ws-manager.ts
@@ -79,6 +79,10 @@ const BI_SAMPLES_REPOSITORY_URL = process.env.BI_SAMPLES_REPOSITORY_URL;
 const BI_SAMPLES_REPOSITORY_BRANCH = 'main';
 const BI_SAMPLES_REPOSITORY_SUBDIRECTORY = '/ballerina-integrator';
 const BI_PREBUILT_INTEGRATIONS_URL = process.env.BI_PREBUILT_INTEGRATIONS_URL;
+const BI_HIDDEN_SAMPLE_IDS = new Set([
+    "shipment-processor",
+    "real-time-error-notifier",
+]);
 
 export class MainWsManager implements WIVisualizerAPI {
     private subProjectReports: Map<string, string> = new Map();
@@ -408,6 +412,13 @@ export class MainWsManager implements WIVisualizerAPI {
                         zipFileName: samples[i][4],
                         isAvailable: samples[i][5]
                     };
+
+                    // Hide BI samples that are currently not working in WSO2 Integrator
+                    // until their runtime issues are resolved.
+                    if (params.runtime === "WSO2: BI" && BI_HIDDEN_SAMPLE_IDS.has(sample.zipFileName)) {
+                        continue;
+                    }
+
                     sampleList.push(sample);
                 }
 


### PR DESCRIPTION
## Summary
- hide `shipment-processor` and `real-time-error-notifier` from the BI Browse Samples list
- keep the filtering in the extension-side sample mapping so unsupported samples are not sent to the webview
- add a short code comment explaining the temporary suppression

## Issue
- Fixes #646

## Testing
- not run (not requested)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sample filtering to exclude specific samples when using WSO2: BI runtime, ensuring only applicable samples are displayed to users in this configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->