### PR TITLE
Simplify About dialog details

### DIFF
--- a/patches/productNameChange.diff
+++ b/patches/productNameChange.diff
@@ -48,15 +48,12 @@ Index: product-integrator/lib/vscode/src/vs/platform/dialogs/electron-browser/di
 -		version = `${version} (Universal)`;
 -	}
 +	const version = (productService as IWIProductService).wiversion ?? productService.version ?? 'Unknown';
-+	const builtInExtensions = productService.builtInExtensions?.length
-+		? `\n${localize('aboutBuiltInExtensions', "Built-in Extensions:")}\n${productService.builtInExtensions.filter(ext => ext.name.startsWith('wso2.')).map(extension => `${extension.name.split('.')[1]}: ${extension.version}`).join('\n')}`
-+		: '';
  
 -	const getDetails = (useAgo: boolean): string => {
 +	const getDetails = (): string => {
  		return localize({ key: 'aboutDetail', comment: ['Electron, Chromium, Node.js and V8 are product names that need no translation'] },
 -			"Version: {0}\nCommit: {1}\nDate: {2}\nElectron: {3}\nElectronBuildId: {4}\nChromium: {5}\nNode.js: {6}\nV8: {7}\nOS: {8}",
-+			"Version: {0}\nOS: {1}{2}",
++			"Version: {0}\nOS: {1}",
  			version,
 -			productService.commit || 'Unknown',
 -			productService.date ? `${productService.date}${useAgo ? ' (' + fromNow(new Date(productService.date), true) + ')' : ''}` : 'Unknown',
@@ -66,8 +63,7 @@ Index: product-integrator/lib/vscode/src/vs/platform/dialogs/electron-browser/di
 -			process.versions['node'],
 -			process.versions['v8'],
 -			`${osProps.type} ${osProps.arch} ${osProps.release}${isLinuxSnap ? ' snap' : ''}`
-+			`${osProps.type} ${osProps.arch} ${osProps.release}${isLinuxSnap ? ' snap' : ''}`,
-+			builtInExtensions
++			`${osProps.type} ${osProps.arch} ${osProps.release}${isLinuxSnap ? ' snap' : ''}`
  		);
  	};
  

--- a/wi/wi-extension/src/cloud/activate.ts
+++ b/wi/wi-extension/src/cloud/activate.ts
@@ -28,6 +28,7 @@ import { contextStore } from "./stores/context-store";
 import { dataCacheStore } from "./stores/data-cache-store";
 import { locationStore } from "./stores/location-store";
 import { activateURIHandlers } from "./cloud-uri-handlers";
+import { formatInstalledPluginLogLines } from "./plugin-log";
 import { getExtVersion } from "../utils/commonUtils";
 
 /**
@@ -45,6 +46,9 @@ export async function activateCloudFunctionality(context: vscode.ExtensionContex
 	// 2. Log versions
 	ext.log(`Extension version: ${getExtVersion(context)}`);
 	ext.log(`CLI version: ${getCliVersion()}`);
+	for (const line of formatInstalledPluginLogLines(vscode.extensions.all)) {
+		ext.log(line);
+	}
 
 	// 3. Rehydrate persistent stores
 	await contextStore.persist.rehydrate();

--- a/wi/wi-extension/src/cloud/plugin-log.ts
+++ b/wi/wi-extension/src/cloud/plugin-log.ts
@@ -1,0 +1,21 @@
+interface InstalledPluginLike {
+	id: string;
+	packageJSON?: {
+		version?: string;
+	};
+}
+
+export function formatInstalledPluginLogLines(extensions: readonly InstalledPluginLike[]): string[] {
+	const lines = ["Installed plugins:"];
+
+	if (extensions.length === 0) {
+		return [...lines, "(none)"];
+	}
+
+	return [
+		...lines,
+		...[...extensions]
+			.sort((left: InstalledPluginLike, right: InstalledPluginLike) => left.id.localeCompare(right.id))
+			.map((extension: InstalledPluginLike) => `${extension.id}: ${extension.packageJSON?.version ?? "Unknown"}`),
+	];
+}

--- a/wi/wi-extension/src/cloud/plugin-log.ts
+++ b/wi/wi-extension/src/cloud/plugin-log.ts
@@ -7,15 +7,20 @@ interface InstalledPluginLike {
 
 export function formatInstalledPluginLogLines(extensions: readonly InstalledPluginLike[]): string[] {
 	const lines = ["Installed plugins:"];
+	const wso2Extensions = [...extensions]
+		.filter((extension: InstalledPluginLike) => extension.id.startsWith("wso2."))
+		.map((extension: InstalledPluginLike) => ({
+			name: extension.id.slice("wso2.".length),
+			version: extension.packageJSON?.version ?? "Unknown",
+		}))
+		.sort((left, right) => left.name.localeCompare(right.name));
 
-	if (extensions.length === 0) {
+	if (wso2Extensions.length === 0) {
 		return [...lines, "(none)"];
 	}
 
 	return [
 		...lines,
-		...[...extensions]
-			.sort((left: InstalledPluginLike, right: InstalledPluginLike) => left.id.localeCompare(right.id))
-			.map((extension: InstalledPluginLike) => `${extension.id}: ${extension.packageJSON?.version ?? "Unknown"}`),
+		...wso2Extensions.map((extension) => `${extension.name}: ${extension.version}`),
 	];
 }

--- a/wi/wi-extension/src/test/suite/plugin-log.test.ts
+++ b/wi/wi-extension/src/test/suite/plugin-log.test.ts
@@ -1,0 +1,28 @@
+import * as assert from "assert";
+import { formatInstalledPluginLogLines } from "../../cloud/plugin-log";
+
+describe("plugin log formatting", () => {
+	it("sorts installed plugins by id and includes versions", () => {
+		const lines = formatInstalledPluginLogLines([
+			{ id: "wso2.integrator", packageJSON: { version: "0.2.2" } },
+			{ id: "ms-python.python", packageJSON: { version: "2026.1.0" } },
+			{ id: "redhat.java", packageJSON: { version: "1.42.0" } },
+		]);
+
+		assert.deepStrictEqual(lines, [
+			"Installed plugins:",
+			"ms-python.python: 2026.1.0",
+			"redhat.java: 1.42.0",
+			"wso2.integrator: 0.2.2",
+		]);
+	});
+
+	it("handles an empty plugin list", () => {
+		const lines = formatInstalledPluginLogLines([]);
+
+		assert.deepStrictEqual(lines, [
+			"Installed plugins:",
+			"(none)",
+		]);
+	});
+});

--- a/wi/wi-extension/src/test/suite/plugin-log.test.ts
+++ b/wi/wi-extension/src/test/suite/plugin-log.test.ts
@@ -2,18 +2,20 @@ import * as assert from "assert";
 import { formatInstalledPluginLogLines } from "../../cloud/plugin-log";
 
 describe("plugin log formatting", () => {
-	it("sorts installed plugins by id and includes versions", () => {
+	it("logs only WSO2 extensions using the old About-popup names", () => {
 		const lines = formatInstalledPluginLogLines([
 			{ id: "wso2.integrator", packageJSON: { version: "0.2.2" } },
 			{ id: "ms-python.python", packageJSON: { version: "2026.1.0" } },
 			{ id: "redhat.java", packageJSON: { version: "1.42.0" } },
+			{ id: "wso2.wso2-platform", packageJSON: { version: "1.0.23" } },
+			{ id: "wso2.micro-integrator", packageJSON: { version: "3.1.526041009" } },
 		]);
 
 		assert.deepStrictEqual(lines, [
 			"Installed plugins:",
-			"ms-python.python: 2026.1.0",
-			"redhat.java: 1.42.0",
-			"wso2.integrator: 0.2.2",
+			"integrator: 0.2.2",
+			"micro-integrator: 3.1.526041009",
+			"wso2-platform: 1.0.23",
 		]);
 	});
 


### PR DESCRIPTION
## Summary
- simplify the WSO2 Integrator About dialog to show only version and OS
- move installed plugin details into the WSO2 Integrator output log at startup
- add a focused plugin-log formatting regression test

## Root Cause
The About dialog patch had expanded to include built-in extension details, which made the dialog too noisy for the `5.0.0-alpha6` product line.

## Test Plan
- `cd wi/wi-extension && ./node_modules/.bin/tsc -p . --outDir out`
- `cd wi/wi-extension && ./node_modules/.bin/mocha out/test/suite/plugin-log.test.js`
- `cd wi/wi-extension && ./node_modules/.bin/tsc -p . --noEmit`

Fixed: https://github.com/wso2/product-integrator/issues/744
