### PR TITLE
Add smoke test workflow (wso2ipw hello-world-service)

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -115,6 +115,13 @@ jobs:
       ballerina_extension_source: ${{ github.event.inputs.ballerina_extension_source }}
       build_packed_installers: ${{ github.event.inputs.build_packed_installers == 'true' }}
 
+  smoke-test:
+    if: ${{ github.event.inputs.build_packed_installers == 'true' }}
+    needs: compile
+    uses: ./.github/workflows/smoke-test.yml
+    with:
+      artifact_name: Product-Integrator-TAR
+
   build-macos:
     if: ${{ github.event.inputs.build_macos == 'true' }}
     name: Build (macOS)
@@ -845,8 +852,8 @@ jobs:
   create-release:
     name: Create Release
     runs-on: ubuntu-latest
-    needs: [resolve-versions, compile, build-macos, build-windows]
-    if: always() && (needs.compile.result == 'success') && (github.event.inputs.build_packed_installers == 'false') && (github.event.inputs.delivery_mode == 'archive')
+    needs: [resolve-versions, compile, build-macos, build-windows, smoke-test]
+    if: always() && (needs.compile.result == 'success') && (needs.smoke-test.result == 'success' || needs.smoke-test.result == 'skipped') && (github.event.inputs.build_packed_installers == 'false') && (github.event.inputs.delivery_mode == 'archive')
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -889,10 +896,11 @@ jobs:
   publish-github-release:
     name: Publish GitHub Release
     runs-on: ubuntu-latest
-    needs: [resolve-versions, compile, build-macos, build-windows]
+    needs: [resolve-versions, compile, build-macos, build-windows, smoke-test]
     if: |
       always() &&
       (needs.compile.result == 'success') &&
+      (needs.smoke-test.result == 'success') &&
       (github.event.inputs.delivery_mode == 'github-release') &&
       (github.event.inputs.build_packed_installers == 'true')
     steps:

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,0 +1,124 @@
+name: Smoke Test
+
+on:
+  workflow_call:
+    inputs:
+      artifact_name:
+        description: 'Name of the uploaded artifact containing the Linux tar.gz'
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      integrator_version:
+        description: 'Download from GitHub Release instead of artifact (e.g. 5.0.0-alpha6)'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  smoke-test:
+    name: Smoke Test (Linux)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      DISPLAY: ':99'
+      WSO2IPW_ELECTRON_ARGS: '--no-sandbox'
+    steps:
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            xvfb \
+            libgtk-3-0 libgbm1 libnss3 libxss1 libasound2t64 \
+            libx11-xcb1 libdrm2 libxcomposite1 libxdamage1 \
+            libxrandr2 libatk-bridge2.0-0 libatspi2.0-0 libcups2
+
+      - name: Start Xvfb
+        run: |
+          Xvfb :99 -screen 0 1920x1080x24 &
+          sleep 2
+
+      - name: Download build artifact
+        if: ${{ inputs.artifact_name != '' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: artifact/
+
+      - name: Download from GitHub Release
+        if: ${{ inputs.integrator_version != '' && inputs.artifact_name == '' }}
+        run: |
+          VERSION="${{ inputs.integrator_version }}"
+          TARBALL="wso2-integrator-${VERSION}-linux-x64.tar.gz"
+          URL="https://github.com/wso2/product-integrator/releases/download/v${VERSION}/${TARBALL}"
+          mkdir -p artifact
+          curl -fSL -o "artifact/${TARBALL}" "$URL"
+
+      - name: Extract and locate Electron binary
+        run: |
+          cd artifact
+          TAR=$(ls *.tar.gz | head -1)
+          echo "Extracting: $TAR"
+          tar -xzf "$TAR"
+          # The packed tar.gz contains wso2-integrator/wso2-integrator (ELF Electron binary)
+          # and wso2-integrator/bin/wso2-integrator (shell wrapper).
+          # Playwright needs the actual Electron binary.
+          BINARY=$(find . -maxdepth 2 -name 'wso2-integrator' -type f ! -path '*/bin/*' | head -1)
+          if [ -z "$BINARY" ]; then
+            echo "ERROR: Could not find wso2-integrator binary"
+            find . -maxdepth 3 -type f | head -30
+            exit 1
+          fi
+          chmod +x "$BINARY"
+          REAL=$(realpath "$BINARY")
+          echo "WSO2_INTEGRATOR_PATH=$REAL" >> "$GITHUB_ENV"
+          echo "Found: $(file $REAL)"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install wso2ipw
+        run: npm install -g wso2ipw@0.1.4
+
+      - name: Run smoke test
+        run: |
+          EXAMPLES="$(npm root -g)/wso2ipw/examples/hello-world-service"
+          for step in "$EXAMPLES"/0*.sh; do
+            name=$(basename "$step")
+            echo ""
+            echo "═══ $name ═══"
+            bash "$step" || {
+              echo "FAIL: $name" >&2
+              wso2ipw screenshot "failure-${name%.sh}.png" 2>/dev/null || true
+              wso2ipw close 2>/dev/null || true
+              exit 1
+            }
+            echo "✓ $name"
+          done
+          echo ""
+          echo "════════════════════════════════════════════"
+          echo "  SMOKE TEST PASSED ✓"
+          echo "════════════════════════════════════════════"
+          wso2ipw close 2>/dev/null || true
+
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-test-logs
+          path: |
+            /home/runner/.wso2ipw/*/daemon.log
+            /home/runner/.wso2ipw/*/daemon.err
+          if-no-files-found: ignore
+
+      - name: Upload screenshots on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-test-screenshots
+          path: failure-*.png
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary

Same as #814 but targeting the `5.0.x` branch. Adapted for the `resolve-versions` job present in this branch's build-and-release.yml.

Adds an end-to-end smoke test that runs after the Linux pack is built, gating the release.

### What it does

1. Extracts the packed Linux tar.gz artifact (`Product-Integrator-TAR`)
2. Launches WSO2 Integrator headlessly (Xvfb + Playwright via [wso2ipw](https://www.npmjs.com/package/wso2ipw))
3. Creates an HTTP service → adds GET /hello → adds Return `"Hello, World!"`
4. Runs the integration, verifies `GET /hello` returns `"Hello, World!"`

### Release gating

- `publish-github-release` now **requires** smoke-test success — blocks release on failure
- `create-release` (archive mode) allows smoke-test skipped (no packed tar.gz to test)

### Files changed

- `.github/workflows/smoke-test.yml` — new reusable workflow (`workflow_call` from build-and-release + standalone `workflow_dispatch` to test against any release)
- `.github/workflows/build-and-release.yml` — wires smoke-test after compile, adds to release job `needs`

### Tested

Validated on [manuranga/wso2i-smoke-try](https://github.com/manuranga/wso2i-smoke-try/actions) against v5.0.0-alpha6:

```
✓ 01-open.sh
✓ 02-create-integration.sh
✓ 03-add-http-service.sh
✓ 04-add-get-resource.sh
✓ 05-add-return-node.sh
✓ 06-run-and-verify.sh  →  ✅ GET /hello → Hello, World!
SMOKE TEST PASSED ✓
```
