### PR TITLE
Un-ignore ci/build/ so daily-build PRs can stage the properties file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,11 @@ installers/linux-deb/package/usr/share/wso2-integrator
 lib/
 build/
 !lib/vscode
+# `build/` above is intentionally broad for VSCode build output, but it
+# also matches tracked files under ci/build/ (component-versions.properties,
+# update-product.sh). Re-include the directory so tooling can stage those
+# files without `git add --force`.
+!ci/build/
 
 # Rush temporary files
 common/deploy/


### PR DESCRIPTION
## Summary

The broad `build/` rule in `.gitignore` (no leading slash) matches any directory named `build` at any depth, including `ci/build`. The two tracked files under `ci/build/` (`component-versions.properties`, `update-product.sh`) were committed before the rule was added, so they stay tracked — but `git add` refuses to re-stage them without `--force`:

```
The following paths are ignored by one of your .gitignore files:
ci/build
hint: Use -f if you really want to add them.
```

This breaks the Ballerina daily-build bot on [wso2/vscode-extensions#2039](https://github.com/wso2/vscode-extensions/pull/2039), whose `UpdateProductIntegrator` job opens automated PRs that bump `ballerina.extension.version` here. That PR currently carries a `git add -f` workaround, which can be removed once this lands.

Adds `!ci/build/` to re-include the directory. No files change under `ci/build/` itself.

## Test plan

- [x] `git check-ignore -v --no-index ci/build` → matches `!ci/build/` (un-ignored)
- [x] `git check-ignore -v --no-index ci/build/component-versions.properties` → exit 1 (not ignored)
- [x] `git check-ignore -v --no-index ci/build/new.txt` → exit 1 (future siblings also covered)
- [x] After merge, cherry-pick the same change to `5.0.x` (the other branch the daily-build bot targets).