### PR TITLE
Un-ignore ci/build/ so daily-build PRs can stage the properties file (5.0.x)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,11 @@ installers/linux-deb/package/usr/share/wso2-integrator
 lib/
 build/
 !lib/vscode
+# `build/` above is intentionally broad for VSCode build output, but it
+# also matches tracked files under ci/build/ (component-versions.properties,
+# update-product.sh). Re-include the directory so tooling can stage those
+# files without `git add --force`.
+!ci/build/
 
 # Rush temporary files
 common/deploy/


### PR DESCRIPTION
## Summary

Backport of #1064 to `5.0.x`. Same `.gitignore` rule (`build/`) incorrectly ignores the tracked `ci/build/` directory on this branch too. The Ballerina daily-build bot's `release/bi-1.8.x` leg targets `productIntegratorBranch=5.0.x`, so it needs this fix to drop the `git add --force` workaround in [wso2/vscode-extensions#2039](https://github.com/wso2/vscode-extensions/pull/2039).

Cherry-picked from main (commit 840984a, now merged as #1064).

## Test plan

- [x] `git check-ignore -v --no-index ci/build` → matches `!ci/build/` (un-ignored)
- [x] `git check-ignore -v --no-index ci/build/component-versions.properties` → exit 1 (not ignored)