### PR TITLE
Update BI extension daily snapshot to 5.9.4-260423-0616

### DIFF
--- a/ci/build/component-versions.properties
+++ b/ci/build/component-versions.properties
@@ -1,7 +1,7 @@
 integrator.version=5.0.0-alpha10
 ballerina.version=2201.13.3
 icp.version=2.0.0-alpha8
-ballerina.extension.version=5.9.426042206
+ballerina.extension.version=5.9.4-260423-0616
 ballerina.jre.version=3.0.2
 wso2.hurl-client.extension.version=0.9.4
 wso2.mcp-server-inspector.extension.version=0.7.2


### PR DESCRIPTION
## Purpose

Updates the BI extension daily snapshot version to `5.9.4-260423-0616` for the daily release in the `5.0.x` branch.

## Changes

- Update snapshot version to `5.9.4-260423-0616`.
- Target branch: `5.0.x`.