### PR TITLE
Update BI extension daily snapshot to 5.10.0-260423-0616

### DIFF
--- a/ci/build/component-versions.properties
+++ b/ci/build/component-versions.properties
@@ -1,7 +1,7 @@
 integrator.version=5.1.0-m2
 ballerina.version=2201.13.3
 icp.version=2.0.0-alpha7
-ballerina.extension.version=5.9.426041020
+ballerina.extension.version=5.10.0-260423-0616
 wso2.platform.extension.version=1.0.23
 wso2.hurl-client.extension.version=0.9.3
 wso2.mcp-server-inspector.extension.version=0.7.2


### PR DESCRIPTION
## Purpose

Updates the BI extension daily snapshot version to `5.10.0-260423-0616` for the daily release in the `main` branch.

## Changes

- Update snapshot version to `5.10.0-260423-0616`.
- Target branch: `main`.