### PR TITLE
Bump integrator version to 5.0.0-alpha12

### DIFF
--- a/ci/build/component-versions.properties
+++ b/ci/build/component-versions.properties
@@ -1,4 +1,4 @@
-integrator.version=5.0.0-alpha11
+integrator.version=5.0.0-alpha12
 ballerina.version=2201.13.3
 icp.version=2.0.0-alpha8
 ballerina.extension.version=5.9.426042206


### PR DESCRIPTION
## Summary

- Bumps `integrator.version` from `5.0.0-alpha11` to `5.0.0-alpha12` in `ci/build/component-versions.properties`

## Details

The `build-and-release.yml` workflow reads versions from `ci/build/component-versions.properties` via the `resolve-versions` job. When run with `delivery_mode: github-release`, this version is used as the GitHub Release tag (`v5.0.0-alpha12`) and installer filenames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)