### PR TITLE
Unify multi-project configure destination UX

### DIFF
--- a/wi/wi-webviews/src/views/ImportIntegration/components/MultiProjectFormFields.tsx
+++ b/wi/wi-webviews/src/views/ImportIntegration/components/MultiProjectFormFields.tsx
@@ -64,8 +64,13 @@ export function MultiProjectFormFields({ formData, onFormDataChange, pathError, 
     useEffect(() => {
         (async () => {
             if (!formData.path) {
-                const currentDir = await wsClient.getWorkspaceRoot();
-                onFormDataChange({ path: currentDir.path });
+                try {
+                    const currentDir = await wsClient.getWorkspaceRoot();
+                    const path = currentDir.path || (await wsClient.getDefaultCreationPath()).path;
+                    onFormDataChange({ path });
+                } catch (error) {
+                    console.error("Failed to fetch default creation path:", error);
+                }
             }
         })();
     }, []);
@@ -78,6 +83,7 @@ export function MultiProjectFormFields({ formData, onFormDataChange, pathError, 
                     label="Select Path"
                     placeholder="Enter path or browse to select a folder..."
                     selectedPath={formData.path}
+                    required={true}
                     onSelect={handleProjectDirSelection}
                     onChange={(value) => onFormDataChange({ path: value })}
                     errorMsg={pathError}
@@ -101,7 +107,6 @@ export function MultiProjectFormFields({ formData, onFormDataChange, pathError, 
                         value={formData.rootFolderName}
                         label="Folder Name"
                         placeholder="Enter folder name"
-                        autoFocus={true}
                         required={true}
                         errorMsg={folderNameError || ""}
                     />

--- a/wi/wi-webviews/src/views/ImportIntegration/components/MultiProjectFormFields.tsx
+++ b/wi/wi-webviews/src/views/ImportIntegration/components/MultiProjectFormFields.tsx
@@ -107,6 +107,7 @@ export function MultiProjectFormFields({ formData, onFormDataChange, pathError, 
                         value={formData.rootFolderName}
                         label="Folder Name"
                         placeholder="Enter folder name"
+                        autoFocus={true}
                         required={true}
                         errorMsg={folderNameError || ""}
                     />

--- a/wi/wi-webviews/src/views/ImportIntegration/components/MultiProjectFormFields.tsx
+++ b/wi/wi-webviews/src/views/ImportIntegration/components/MultiProjectFormFields.tsx
@@ -62,17 +62,27 @@ export function MultiProjectFormFields({ formData, onFormDataChange, pathError, 
     };
 
     useEffect(() => {
+        let cancelled = false;
         (async () => {
             if (!formData.path) {
+                let path: string | undefined;
                 try {
                     const currentDir = await wsClient.getWorkspaceRoot();
-                    const path = currentDir.path || (await wsClient.getDefaultCreationPath()).path;
-                    onFormDataChange({ path });
+                    path = currentDir.path || (await wsClient.getDefaultCreationPath()).path;
                 } catch (error) {
-                    console.error("Failed to fetch default creation path:", error);
+                    console.error("getWorkspaceRoot failed, trying fallback:", error);
+                    try {
+                        path = (await wsClient.getDefaultCreationPath()).path;
+                    } catch (fallbackError) {
+                        console.error("Failed to fetch default creation path:", fallbackError);
+                    }
+                }
+                if (!cancelled && path) {
+                    onFormDataChange({ path });
                 }
             }
         })();
+        return () => { cancelled = true; };
     }, []);
 
     return (


### PR DESCRIPTION
## Purpose
$subject.

Fixes #1053

- Add required marker to path field in multi-project Configure Destination step
- Use default path fallback logic matching single-project (getWorkspaceRoot, then getDefaultCreationPath)
- Ensures consistent required field indicators, default path population, and focus behavior between single and multi-project flows in the migration wizard

Sample:
<img width="1074" height="394" alt="Screenshot 2026-04-28 at 11 40 13" src="https://github.com/user-attachments/assets/3635e304-0f8f-4e86-bee5-f4f999d4d263" />

