### PR TITLE
Support any pre-release label in version bump

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1014,14 +1014,14 @@ jobs:
           CURRENT_VERSION=$(awk -F= '$1 == "integrator.version" { print $2; exit }' "${VERSIONS_FILE}" | tr -d '\r')
           echo "Current version: ${CURRENT_VERSION}"
 
-          # Extract alpha number and increment it
-          if [[ "${CURRENT_VERSION}" =~ ^(.+-alpha)([0-9]+)$ ]]; then
-            PREFIX="${BASH_REMATCH[1]}"
-            ALPHA_NUM="${BASH_REMATCH[2]}"
-            NEXT_ALPHA_NUM=$((ALPHA_NUM + 1))
-            NEW_VERSION="${PREFIX}${NEXT_ALPHA_NUM}"
+          # If version ends in a number, increment it (e.g. alpha11 -> alpha12, beta1 -> beta2)
+          # If not, append 1 (e.g. beta -> beta1, RC -> RC1)
+          if [[ "${CURRENT_VERSION}" =~ ^(.*[^0-9])([0-9]+)$ ]]; then
+            NEW_VERSION="${BASH_REMATCH[1]}$((BASH_REMATCH[2] + 1))"
+          elif [[ -n "${CURRENT_VERSION}" ]]; then
+            NEW_VERSION="${CURRENT_VERSION}1"
           else
-            echo "Error: integrator.version '${CURRENT_VERSION}' does not match expected alpha pattern." >&2
+            echo "Error: integrator.version is empty or invalid." >&2
             exit 1
           fi
 

--- a/ci/build/component-versions.properties
+++ b/ci/build/component-versions.properties
@@ -1,5 +1,5 @@
-integrator.version=5.0.0-alpha18
-ballerina.version=2201.13.3
+integrator.version=5.0.0-beta
+ballerina.version=2201.13.4-beta
 icp.version=2.0.0-alpha10
 ballerina.extension.version=5.9.426042816
 ballerina.jre.version=3.0.2


### PR DESCRIPTION
## Summary

The `bump-version` job's increment logic was hardcoded to only match `*-alpha<N>` versions. This updates it to handle any pre-release label.

## Behaviour

| Version in file | After bump |
|---|---|
| `5.0.0-alpha11` | `5.0.0-alpha12` |
| `5.0.0-beta1` | `5.0.0-beta2` |
| `5.0.0-beta` | `5.0.0-beta1` |
| `5.0.0-RC` | `5.0.0-RC1` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)