### PR TITLE
Update mcp-server-inspector to 0.7.4

### DIFF
--- a/ci/build/component-versions.properties
+++ b/ci/build/component-versions.properties
@@ -4,6 +4,6 @@ icp.version=2.0.0-beta
 ballerina.extension.version=5.9.4-260430-0603
 ballerina.jre.version=3.0.2
 wso2.hurl-client.extension.version=0.9.4
-wso2.mcp-server-inspector.extension.version=0.7.3
+wso2.mcp-server-inspector.extension.version=0.7.4
 wso2.micro-integrator.extension.version=3.1.526042615
 wso2.streaming-integrator.extension.version=0.1.29621565


### PR DESCRIPTION
## Purpose

Updates the `mcp-server-inspector` extension dependency version to `0.7.4`.

## Description

This PR updates the extension version to the latest release (`0.7.4`). This change ensures that the CI pipeline utilizes the most recent version of the extension when building the WSO2 integrator.

## Changes

- Update `mcp-server-inspector` version to `0.7.4` in build configuration.
- Sync CI pipeline dependencies with the latest extension release.