### PR TITLE
Apply vscode patches in CI before building

### DIFF
--- a/.github/workflows/build-macos-dmg-no-wso2-extensions.yml
+++ b/.github/workflows/build-macos-dmg-no-wso2-extensions.yml
@@ -181,6 +181,14 @@ jobs:
             npm run download-builtin-extensions
           fi
 
+      - name: Compile core output
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          npm run extensions-ci
+          npm run core-ci-pr
+          npm exec -- npm-run-all -lp eslint valid-layers-check define-class-fields-check vscode-dts-compile-check tsec-compile-check
+
       - name: Build client
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-macos-dmg-no-wso2-extensions.yml
+++ b/.github/workflows/build-macos-dmg-no-wso2-extensions.yml
@@ -1,0 +1,265 @@
+name: Build macOS DMG Without WSO2 Built-In Extensions
+
+on:
+  workflow_dispatch:
+    inputs:
+      integrator_version:
+        description: 'Integrator version to brand/package. Leave empty to use ci/build/component-versions.properties.'
+        required: false
+        type: string
+      ballerina_version:
+        description: 'Ballerina runtime version to package. Leave empty to use ci/build/component-versions.properties.'
+        required: false
+        type: string
+      icp_version:
+        description: 'ICP version to package. Leave empty to use ci/build/component-versions.properties.'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  resolve-versions:
+    name: Resolve Component Versions
+    runs-on: ubuntu-latest
+    outputs:
+      ballerina_version: ${{ steps.read-versions.outputs.ballerina_version }}
+      icp_version: ${{ steps.read-versions.outputs.icp_version }}
+      integrator_version: ${{ steps.read-versions.outputs.integrator_version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Read versions file
+        id: read-versions
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          VERSIONS_FILE="ci/build/component-versions.properties"
+          if [ ! -f "${VERSIONS_FILE}" ]; then
+            echo "Error: ${VERSIONS_FILE} does not exist." >&2
+            exit 1
+          fi
+
+          read_property() {
+            local key="$1"
+            awk -F= -v property_key="$key" '$1 == property_key { print substr($0, index($0, "=") + 1); exit }' "${VERSIONS_FILE}" | tr -d '\r'
+          }
+
+          BALLERINA_VERSION="${{ github.event.inputs.ballerina_version }}"
+          ICP_VERSION="${{ github.event.inputs.icp_version }}"
+          INTEGRATOR_VERSION="${{ github.event.inputs.integrator_version }}"
+
+          BALLERINA_VERSION="${BALLERINA_VERSION:-$(read_property "ballerina.version")}"
+          ICP_VERSION="${ICP_VERSION:-$(read_property "icp.version")}"
+          INTEGRATOR_VERSION="${INTEGRATOR_VERSION:-$(read_property "integrator.version")}"
+
+          if [ -z "${BALLERINA_VERSION}" ] || [ -z "${ICP_VERSION}" ] || [ -z "${INTEGRATOR_VERSION}" ]; then
+            echo "Error: ballerina_version, icp_version, and integrator_version must resolve to non-empty values." >&2
+            exit 1
+          fi
+
+          echo "ballerina_version=${BALLERINA_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "icp_version=${ICP_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "integrator_version=${INTEGRATOR_VERSION}" >> "$GITHUB_OUTPUT"
+
+  build-macos-dmg:
+    name: Build Stripped macOS DMG
+    runs-on: macos-latest
+    needs: resolve-versions
+    defaults:
+      run:
+        working-directory: lib/vscode
+    env:
+      INTEGRATOR_VERSION: ${{ needs.resolve-versions.outputs.integrator_version }}
+      BALLERINA_VERSION: ${{ needs.resolve-versions.outputs.ballerina_version }}
+      ICP_VERSION: ${{ needs.resolve-versions.outputs.icp_version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: lib/vscode/.nvmrc
+          cache: npm
+          cache-dependency-path: lib/vscode/package-lock.json
+
+      - name: Cache Rust toolchain
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: cargo-toolchain-macos-arm64-${{ hashFiles('lib/vscode/cli/Cargo.lock') }}
+          restore-keys: |
+            cargo-toolchain-macos-arm64-
+            cargo-toolchain-macos-
+
+      - name: Cache CLI compilation
+        id: cache-cli
+        uses: actions/cache@v4
+        with:
+          path: |
+            lib/vscode/cli/target/
+          key: cli-macos-arm64-stripped-${{ hashFiles('patches/*.diff', 'lib/vscode/cli/Cargo.lock', 'lib/vscode/cli/src/**/*.rs', 'lib/vscode/cli/Cargo.toml') }}
+          restore-keys: |
+            cli-macos-arm64-stripped-
+            cli-macos-arm64-
+
+      - name: Cache native modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            lib/vscode/node_modules
+            lib/vscode/.build/node_modules_cache
+          key: native-modules-macos-arm64-${{ hashFiles('lib/vscode/package-lock.json', 'patches/*.diff') }}
+          restore-keys: |
+            native-modules-macos-arm64-
+            native-modules-macos-
+
+      - name: Cache built-in extensions
+        id: cache-extensions
+        uses: actions/cache@v4
+        with:
+          path: |
+            lib/vscode/.build/builtInExtensions
+            lib/vscode/.build/extensions
+          key: extensions-macos-arm64-no-wso2-builtins-${{ hashFiles('patches/*.diff', 'ci/build/update-product.sh', 'lib/vscode/package.json', 'ci/build/component-versions.properties') }}
+          restore-keys: |
+            extensions-macos-arm64-no-wso2-builtins-
+
+      - name: Install quilt
+        run: brew install quilt
+
+      - name: Apply patches
+        run: quilt push -a
+
+      - name: Update product.json and branding
+        working-directory: .
+        run: |
+          chmod +x ./ci/build/update-product.sh
+          ./ci/build/update-product.sh "${INTEGRATOR_VERSION}" no-wso2-builtins
+
+      - name: Validate Xcode tools
+        run: |
+          xcode-select -p
+          python3 -m pip install --user setuptools || true
+
+      - name: Install Rust toolchain
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          source "$HOME/.cargo/env"
+          rustup target add aarch64-apple-darwin
+
+      - name: Install dependencies
+        env:
+          ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npm ci
+
+      - name: Mixin distro modules
+        run: |
+          node build/azure-pipelines/distro/mixin-npm.ts || true
+          node build/azure-pipelines/distro/mixin-quality.ts || true
+
+      - name: Install built-in extensions
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ steps.cache-extensions.outputs.cache-hit }}" = "true" ]; then
+            echo "Using cached stripped built-in extensions"
+          else
+            npm run download-builtin-extensions
+          fi
+
+      - name: Build client
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npm run gulp vscode-darwin-arm64-min-ci
+
+      - name: Build CLI
+        run: |
+          source "$HOME/.cargo/env"
+          cd cli
+          TARGET_DIR="./target/aarch64-apple-darwin/release"
+
+          if [ "${{ steps.cache-cli.outputs.cache-hit }}" = "true" ] && [ -f "${TARGET_DIR}/code" ]; then
+            echo "Using cached CLI binary"
+          else
+            cargo build --release --bin=code --target=aarch64-apple-darwin
+          fi
+
+          CLI_BIN="./cli/target/aarch64-apple-darwin/release/code"
+          cd ..
+
+          if [ ! -f "${CLI_BIN}" ]; then
+            echo "CLI binary not found at ${CLI_BIN}" >&2
+            exit 1
+          fi
+
+          CLI_APP_NAME=$(node -p "require('./product.json').tunnelApplicationName")
+          APP_DIR=$(find ../VSCode-darwin-arm64 -name "*.app" -type d | head -1)
+
+          if [ -z "${APP_DIR}" ]; then
+            echo "Could not find .app directory in VSCode-darwin-arm64" >&2
+            exit 1
+          fi
+
+          mkdir -p "${APP_DIR}/Contents/Resources/app/bin"
+          cp "${CLI_BIN}" "${APP_DIR}/Contents/Resources/app/bin/${CLI_APP_NAME}"
+          chmod +x "${APP_DIR}/Contents/Resources/app/bin/${CLI_APP_NAME}"
+
+      - name: Zip app output
+        run: |
+          mkdir -p ../artifacts
+          (
+            cd ..
+            zip -qry "artifacts/VSCode-darwin-arm64.zip" VSCode-darwin-arm64
+          )
+
+      - name: Sign macOS application
+        run: |
+          APP_DIR=$(find "../VSCode-darwin-arm64" -name "*.app" -type d | head -1)
+
+          if [ -z "${APP_DIR}" ]; then
+            echo "No .app directory found to sign" >&2
+            exit 1
+          fi
+
+          codesign --force --deep --sign - "${APP_DIR}"
+          codesign --verify --verbose "${APP_DIR}"
+
+      - name: Build DMG
+        working-directory: .
+        run: |
+          set -euo pipefail
+
+          BALLERINA_VERSION_FILENAME="${BALLERINA_VERSION%-*}"
+          BALLERINA_URL="https://github.com/ballerina-platform/ballerina-distribution/releases/download/v${BALLERINA_VERSION}/ballerina-${BALLERINA_VERSION_FILENAME}-swan-lake-macos-arm.zip"
+
+          ICP_VERSION_FILENAME="${ICP_VERSION%-*}"
+          if [ "${ICP_VERSION}" != "${ICP_VERSION_FILENAME}" ]; then
+            ICP_VERSION_FILENAME="${ICP_VERSION_FILENAME}-SNAPSHOT"
+          fi
+          ICP_URL="https://github.com/wso2/integration-control-plane/releases/download/v${ICP_VERSION}/wso2-integration-control-plane-${ICP_VERSION}.zip"
+
+          cd installers/mac
+          wget -O ballerina.zip "${BALLERINA_URL}"
+          wget -O icp.zip "${ICP_URL}"
+          ./build.sh ballerina.zip "${BALLERINA_VERSION}" ../../lib/artifacts/VSCode-darwin-arm64.zip icp.zip "${INTEGRATOR_VERSION}" arm64
+
+      - name: Upload DMG artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: stripped-wso2-integrator-dmg-arm64
+          path: installers/mac/*.dmg
+          if-no-files-found: error

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -262,6 +262,11 @@ jobs:
           node build/azure-pipelines/distro/mixin-npm.ts || true
           node build/azure-pipelines/distro/mixin-quality.ts || true
 
+      - name: Apply vscode patches
+        run: |
+          patch -p3 < ../../patches/disableVsixChecksumCheck.diff
+          patch -p3 < ../../patches/increaseHeap.diff
+
       - name: Install builtin extensions
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/ci/build/update-product.sh
+++ b/ci/build/update-product.sh
@@ -17,6 +17,7 @@ read_version() {
 
 # Accept integrator version as first arg (optional), otherwise read from source-of-truth file.
 VERSION=${1:-"$(read_version "integrator.version")"}
+PRODUCT_MODE=${2:-"full"}
 BALLERINA_VSIX_PATH=${BALLERINA_VSIX_PATH:-""}
 BALLERINA_EXTENSION_VERSION=${BALLERINA_EXTENSION_VERSION:-"$(read_version "ballerina.extension.version")"}
 WSO2_PLATFORM_EXTENSION_VERSION=$(read_version "wso2.platform.extension.version")
@@ -39,6 +40,15 @@ if [ -z "${VERSION}" ]; then
   exit 1
 fi
 
+case "${PRODUCT_MODE}" in
+  full|no-wso2-builtins)
+    ;;
+  *)
+    echo "Error: unsupported product mode '${PRODUCT_MODE}'. Expected 'full' or 'no-wso2-builtins'." >&2
+    exit 1
+    ;;
+esac
+
 require_non_empty "${WSO2_PLATFORM_EXTENSION_VERSION}" "wso2.platform.extension.version"
 require_non_empty "${WSO2_HURL_CLIENT_EXTENSION_VERSION}" "wso2.hurl-client.extension.version"
 require_non_empty "${WSO2_MCP_SERVER_INSPECTOR_EXTENSION_VERSION}" "wso2.mcp-server-inspector.extension.version"
@@ -54,6 +64,82 @@ if [ -z "${BALLERINA_EXTENSION_VERSION}" ] && [ -z "${BALLERINA_VSIX_PATH}" ]; t
   BALLERINA_EXTENSION_VERSION="latest"
 fi
 WI_EXTENSION_VERSION=$(node -p "require('./wi/wi-extension/package.json').version")
+
+builtin_extensions_entries() {
+  if [ "${PRODUCT_MODE}" = "no-wso2-builtins" ]; then
+    cat <<'STRIPPED_BUILTINS'
+      {
+        "name": "redhat.vscode-yaml",
+        "version": "latest"
+      },
+      {
+        "name": "anweber.httpbook",
+        "version": "latest"
+      },
+      {
+        "name": "anweber.vscode-httpyac",
+        "version": "latest"
+      }
+STRIPPED_BUILTINS
+    return
+  fi
+
+  cat <<FULL_BUILTINS
+      {
+        "name": "redhat.vscode-yaml",
+        "version": "latest"
+      },
+      {
+        "name": "anweber.httpbook",
+        "version": "latest"
+      },
+      {
+        "name": "anweber.vscode-httpyac",
+        "version": "latest"
+      },
+      {
+        "name": "wso2.wso2-platform",
+        "version": "${WSO2_PLATFORM_EXTENSION_VERSION}"
+      },
+      {
+        "name": "wso2.hurl-client",
+        "version": "${WSO2_HURL_CLIENT_EXTENSION_VERSION}"
+      },
+      {
+        "name": "wso2.mcp-server-inspector",
+        "version": "${WSO2_MCP_SERVER_INSPECTOR_EXTENSION_VERSION}"
+      },
+$(if [ -n "${BALLERINA_VSIX_PATH}" ]; then
+cat <<BALLERINA_VSIX_ENTRY
+      {
+        "name": "wso2.ballerina",
+        "vsix": "${BALLERINA_VSIX_PATH}",
+        "version": "${BALLERINA_EXTENSION_VERSION}"
+      },
+BALLERINA_VSIX_ENTRY
+else
+cat <<BALLERINA_MARKETPLACE_ENTRY
+      {
+        "name": "wso2.ballerina",
+        "version": "${BALLERINA_EXTENSION_VERSION}"
+      },
+BALLERINA_MARKETPLACE_ENTRY
+fi)
+      {
+        "name": "wso2.micro-integrator",
+        "version": "${WSO2_MICRO_INTEGRATOR_EXTENSION_VERSION}"
+      },
+      {
+        "name": "wso2.streaming-integrator",
+        "version": "${WSO2_STREAMING_INTEGRATOR_EXTENSION_VERSION}"
+      },
+      {
+        "name": "wso2.wso2-integrator",
+        "vsix": "../../wi/wi-extension/wso2-integrator-${WI_EXTENSION_VERSION}.vsix",
+        "version": "${WI_EXTENSION_VERSION}"
+      }
+FULL_BUILTINS
+}
 
 cat > lib/vscode/product.json <<EOF
 {
@@ -123,59 +209,7 @@ cat > lib/vscode/product.json <<EOF
       }
     },
 	  "builtInExtensions": [
-      {
-        "name": "redhat.vscode-yaml",
-        "version": "latest"
-      },
-      {
-        "name": "anweber.httpbook",
-        "version": "latest"
-      },
-      {
-        "name": "anweber.vscode-httpyac",
-        "version": "latest"
-      },
-      {
-        "name": "wso2.wso2-platform",
-        "version": "${WSO2_PLATFORM_EXTENSION_VERSION}"
-      },
-      {
-        "name": "wso2.hurl-client",
-        "version": "${WSO2_HURL_CLIENT_EXTENSION_VERSION}"
-      },
-      {
-        "name": "wso2.mcp-server-inspector",
-        "version": "${WSO2_MCP_SERVER_INSPECTOR_EXTENSION_VERSION}"
-      },
-$(if [ -n "${BALLERINA_VSIX_PATH}" ]; then
-cat <<BALLERINA_VSIX_ENTRY
-      {
-        "name": "wso2.ballerina",
-        "vsix": "${BALLERINA_VSIX_PATH}",
-        "version": "${BALLERINA_EXTENSION_VERSION}"
-      },
-BALLERINA_VSIX_ENTRY
-else
-cat <<BALLERINA_MARKETPLACE_ENTRY
-      {
-        "name": "wso2.ballerina",
-        "version": "${BALLERINA_EXTENSION_VERSION}"
-      },
-BALLERINA_MARKETPLACE_ENTRY
-fi)
-      {
-        "name": "wso2.micro-integrator",
-        "version": "${WSO2_MICRO_INTEGRATOR_EXTENSION_VERSION}"
-      },
-      {
-        "name": "wso2.streaming-integrator",
-        "version": "${WSO2_STREAMING_INTEGRATOR_EXTENSION_VERSION}"
-      },
-      {
-        "name": "wso2.wso2-integrator",
-        "vsix": "../../wi/wi-extension/wso2-integrator-${WI_EXTENSION_VERSION}.vsix",
-        "version": "${WI_EXTENSION_VERSION}"
-      }
+$(builtin_extensions_entries)
     ],
     "runtimeEnv": {
       "common": {

--- a/patches/lazyGithubAuthStartup.diff
+++ b/patches/lazyGithubAuthStartup.diff
@@ -1,0 +1,253 @@
+Index: product-integrator/lib/vscode/extensions/github-authentication/src/extension.ts
+===================================================================
+--- product-integrator.orig/lib/vscode/extensions/github-authentication/src/extension.ts
++++ product-integrator/lib/vscode/extensions/github-authentication/src/extension.ts
+@@ -5,6 +5,7 @@
+ 
+ import * as vscode from 'vscode';
+ import { GitHubAuthenticationProvider, UriEventHandler } from './github';
++import { LazyAuthenticationProvider } from './lazyAuthenticationProvider';
+ 
+ const settingNotSent = '"github-enterprise.uri" not set';
+ const settingInvalid = '"github-enterprise.uri" invalid';
+@@ -36,6 +37,23 @@
+ 	}
+ }
+ 
++function registerLazyProvider(
++	context: vscode.ExtensionContext,
++	id: string,
++	label: string,
++	supportedAuthorizationServers: readonly vscode.Uri[],
++	factory: () => vscode.AuthenticationProvider & vscode.Disposable
++): vscode.Disposable {
++	const provider = new LazyAuthenticationProvider(factory);
++	return vscode.Disposable.from(
++		provider,
++		vscode.authentication.registerAuthenticationProvider(id, label, provider, {
++			supportsMultipleAccounts: true,
++			supportedAuthorizationServers
++		})
++	);
++}
++
+ function initGHES(context: vscode.ExtensionContext, uriHandler: UriEventHandler): vscode.Disposable {
+ 	const settingValue = vscode.workspace.getConfiguration().get<string>('github-enterprise.uri');
+ 	if (!settingValue) {
+@@ -55,8 +73,12 @@
+ 		return provider;
+ 	}
+ 
+-	const githubEnterpriseAuthProvider = new GitHubAuthenticationProvider(context, uriHandler, uri);
+-	context.subscriptions.push(githubEnterpriseAuthProvider);
++	const githubEnterpriseAuthProvider = registerLazyProvider(
++		context,
++		'github-enterprise',
++		'GitHub Enterprise',
++		[vscode.Uri.joinPath(uri, '/login/oauth')],
++		() => new GitHubAuthenticationProvider(context, uriHandler, uri, false));
+ 	return githubEnterpriseAuthProvider;
+ }
+ 
+@@ -65,7 +87,14 @@
+ 	context.subscriptions.push(uriHandler);
+ 	context.subscriptions.push(vscode.window.registerUriHandler(uriHandler));
+ 
+-	context.subscriptions.push(new GitHubAuthenticationProvider(context, uriHandler));
++	context.subscriptions.push(registerLazyProvider(
++		context,
++		'github',
++		'GitHub',
++		[vscode.Uri.parse('https://github.com/login/oauth')],
++		// Defer creating the real provider until a command explicitly asks for GitHub sessions.
++		() => new GitHubAuthenticationProvider(context, uriHandler, undefined, false)
++	));
+ 
+ 	let before = vscode.workspace.getConfiguration().get<string>('github-enterprise.uri');
+ 	let githubEnterpriseAuthProvider = initGHES(context, uriHandler);
+Index: product-integrator/lib/vscode/extensions/github-authentication/src/github.ts
+===================================================================
+--- product-integrator.orig/lib/vscode/extensions/github-authentication/src/github.ts
++++ product-integrator/lib/vscode/extensions/github-authentication/src/github.ts
+@@ -141,7 +141,8 @@
+ 	constructor(
+ 		private readonly context: vscode.ExtensionContext,
+ 		uriHandler: UriEventHandler,
+-		ghesUri?: vscode.Uri
++		ghesUri?: vscode.Uri,
++		registerAsAuthenticationProvider: boolean = true
+ 	) {
+ 		const { aiKey } = context.extension.packageJSON as { name: string; version: string; aiKey: string };
+ 		this._telemetryReporter = new ExperimentationTelemetry(context, new TelemetryReporter(aiKey));
+@@ -164,26 +165,26 @@
+ 			context.extension.extensionKind,
+ 			ghesUri);
+ 
+-		const supportedAuthorizationServers = ghesUri
+-			? [vscode.Uri.joinPath(ghesUri, '/login/oauth')]
+-			: [vscode.Uri.parse('https://github.com/login/oauth')];
+-		this._disposable = vscode.Disposable.from(
++		const disposables: vscode.Disposable[] = [
+ 			this._telemetryReporter,
+-			vscode.authentication.registerAuthenticationProvider(
+-				type,
+-				this._githubServer.friendlyName,
+-				this,
+-				{
+-					supportsMultipleAccounts: true,
+-					supportedAuthorizationServers
+-				}
+-			),
+ 			this.context.secrets.onDidChange(() => {
+ 				if (this._sessionsPromise) {
+ 					void this.checkForUpdates();
+ 				}
+ 			})
+-		);
++		];
++
++		if (registerAsAuthenticationProvider) {
++			const supportedAuthorizationServers = ghesUri
++				? [vscode.Uri.joinPath(ghesUri, '/login/oauth')]
++				: [vscode.Uri.parse('https://github.com/login/oauth')];
++			disposables.push(vscode.authentication.registerAuthenticationProvider(type, this._githubServer.friendlyName, this, {
++				supportsMultipleAccounts: true,
++				supportedAuthorizationServers
++			}));
++		}
++
++		this._disposable = vscode.Disposable.from(...disposables);
+ 	}
+ 
+ 	dispose() {
+Index: product-integrator/lib/vscode/extensions/github-authentication/src/lazyAuthenticationProvider.ts
+===================================================================
+--- /dev/null
++++ product-integrator/lib/vscode/extensions/github-authentication/src/lazyAuthenticationProvider.ts
+@@ -0,0 +1,45 @@
++/*---------------------------------------------------------------------------------------------
++ *  Copyright (c) Microsoft Corporation. All rights reserved.
++ *  Licensed under the MIT License. See License.txt in the project root for license information.
++ *--------------------------------------------------------------------------------------------*/
++
++import * as vscode from 'vscode';
++
++export class LazyAuthenticationProvider implements vscode.AuthenticationProvider, vscode.Disposable {
++	private readonly _sessionChangeEmitter = new vscode.EventEmitter<vscode.AuthenticationProviderAuthenticationSessionsChangeEvent>();
++	private _provider: (vscode.AuthenticationProvider & vscode.Disposable) | undefined;
++	private _providerListener: vscode.Disposable | undefined;
++
++	constructor(private readonly factory: () => vscode.AuthenticationProvider & vscode.Disposable) { }
++
++	get onDidChangeSessions() {
++		return this._sessionChangeEmitter.event;
++	}
++
++	private getProvider(): vscode.AuthenticationProvider & vscode.Disposable {
++		if (!this._provider) {
++			this._provider = this.factory();
++			this._providerListener = this._provider.onDidChangeSessions(event => this._sessionChangeEmitter.fire(event));
++		}
++
++		return this._provider;
++	}
++
++	getSessions(scopes?: readonly string[], options?: vscode.AuthenticationProviderSessionOptions): Thenable<vscode.AuthenticationSession[]> {
++		return this.getProvider().getSessions(scopes, options);
++	}
++
++	createSession(scopes: readonly string[], options?: vscode.AuthenticationProviderSessionOptions): Thenable<vscode.AuthenticationSession> {
++		return this.getProvider().createSession(scopes, options);
++	}
++
++	removeSession(sessionId: string): Thenable<void> {
++		return this.getProvider().removeSession(sessionId);
++	}
++
++	dispose(): void {
++		this._providerListener?.dispose();
++		this._provider?.dispose();
++		this._sessionChangeEmitter.dispose();
++	}
++}
+Index: product-integrator/lib/vscode/extensions/github-authentication/src/test/lazyAuthenticationProvider.test.ts
+===================================================================
+--- /dev/null
++++ product-integrator/lib/vscode/extensions/github-authentication/src/test/lazyAuthenticationProvider.test.ts
+@@ -0,0 +1,76 @@
++/*---------------------------------------------------------------------------------------------
++ *  Copyright (c) Microsoft Corporation. All rights reserved.
++ *  Licensed under the MIT License. See License.txt in the project root for license information.
++ *--------------------------------------------------------------------------------------------*/
++
++import * as assert from 'assert';
++import * as vscode from 'vscode';
++import { LazyAuthenticationProvider } from '../lazyAuthenticationProvider';
++
++class TestAuthenticationProvider implements vscode.AuthenticationProvider, vscode.Disposable {
++	private readonly _sessionChangeEmitter = new vscode.EventEmitter<vscode.AuthenticationProviderAuthenticationSessionsChangeEvent>();
++	private readonly sessions: vscode.AuthenticationSession[] = [];
++	public readonly onDidChangeSessions = this._sessionChangeEmitter.event;
++	public getSessionsCalls = 0;
++
++	getSessions(): Thenable<vscode.AuthenticationSession[]> {
++		this.getSessionsCalls++;
++		return Promise.resolve(this.sessions);
++	}
++
++	createSession(): Thenable<vscode.AuthenticationSession> {
++		throw new Error('not implemented');
++	}
++
++	removeSession(): Thenable<void> {
++		throw new Error('not implemented');
++	}
++
++	fireChange(event: vscode.AuthenticationProviderAuthenticationSessionsChangeEvent): void {
++		this._sessionChangeEmitter.fire(event);
++	}
++
++	dispose(): void {
++		this._sessionChangeEmitter.dispose();
++	}
++}
++
++suite('LazyAuthenticationProvider', () => {
++	test('does not construct the real provider until a session method is called', async () => {
++		let factoryCalls = 0;
++		const provider = new TestAuthenticationProvider();
++		const lazyProvider = new LazyAuthenticationProvider(() => {
++			factoryCalls++;
++			return provider;
++		});
++
++		assert.strictEqual(factoryCalls, 0);
++
++		await lazyProvider.getSessions();
++
++		assert.strictEqual(factoryCalls, 1);
++		assert.strictEqual(provider.getSessionsCalls, 1);
++	});
++
++	test('forwards session change events after the real provider is materialized', async () => {
++		const provider = new TestAuthenticationProvider();
++		const lazyProvider = new LazyAuthenticationProvider(() => provider);
++		let forwardedEvent: vscode.AuthenticationProviderAuthenticationSessionsChangeEvent | undefined;
++
++		lazyProvider.onDidChangeSessions(event => {
++			forwardedEvent = event;
++		});
++
++		await lazyProvider.getSessions();
++
++		const expectedEvent = {
++			added: [],
++			removed: [],
++			changed: []
++		};
++
++		provider.fireChange(expectedEvent);
++
++		assert.deepStrictEqual(forwardedEvent, expectedEvent);
++	});
++});

--- a/patches/lazyGithubAuthStartup.diff
+++ b/patches/lazyGithubAuthStartup.diff
@@ -34,7 +34,7 @@ Index: product-integrator/lib/vscode/extensions/github-authentication/src/extens
  function initGHES(context: vscode.ExtensionContext, uriHandler: UriEventHandler): vscode.Disposable {
  	const settingValue = vscode.workspace.getConfiguration().get<string>('github-enterprise.uri');
  	if (!settingValue) {
-@@ -55,8 +73,12 @@
+@@ -55,8 +73,13 @@
  		return provider;
  	}
  
@@ -45,11 +45,12 @@ Index: product-integrator/lib/vscode/extensions/github-authentication/src/extens
 +		'github-enterprise',
 +		'GitHub Enterprise',
 +		[vscode.Uri.joinPath(uri, '/login/oauth')],
-+		() => new GitHubAuthenticationProvider(context, uriHandler, uri, false));
++		() => new GitHubAuthenticationProvider(context, uriHandler, uri, false)
++	);
  	return githubEnterpriseAuthProvider;
  }
  
-@@ -65,7 +87,14 @@
+@@ -65,7 +88,14 @@
  	context.subscriptions.push(uriHandler);
  	context.subscriptions.push(vscode.window.registerUriHandler(uriHandler));
  
@@ -69,7 +70,13 @@ Index: product-integrator/lib/vscode/extensions/github-authentication/src/github
 ===================================================================
 --- product-integrator.orig/lib/vscode/extensions/github-authentication/src/github.ts
 +++ product-integrator/lib/vscode/extensions/github-authentication/src/github.ts
-@@ -141,7 +141,8 @@
+@@ -136,12 +136,13 @@
+ 	private readonly _accountsSeen = new Set<string>();
+ 	private readonly _disposable: vscode.Disposable | undefined;
+ 
+-	private _sessionsPromise: Promise<vscode.AuthenticationSession[]>;
++	private _sessionsPromise: Promise<vscode.AuthenticationSession[]> | undefined;
+ 
  	constructor(
  		private readonly context: vscode.ExtensionContext,
  		uriHandler: UriEventHandler,
@@ -79,10 +86,17 @@ Index: product-integrator/lib/vscode/extensions/github-authentication/src/github
  	) {
  		const { aiKey } = context.extension.packageJSON as { name: string; version: string; aiKey: string };
  		this._telemetryReporter = new ExperimentationTelemetry(context, new TelemetryReporter(aiKey));
-@@ -164,26 +165,26 @@
+@@ -164,19 +165,20 @@
  			context.extension.extensionKind,
  			ghesUri);
  
+-		// Contains the current state of the sessions we have available.
+-		this._sessionsPromise = this.readSessions().then((sessions) => {
+-			// fire telemetry after a second to allow the workbench to focus on loading
+-			setTimeout(() => sessions.forEach(s => this.afterSessionLoad(s)), 1000);
+-			return sessions;
+-		});
+-
 -		const supportedAuthorizationServers = ghesUri
 -			? [vscode.Uri.joinPath(ghesUri, '/login/oauth')]
 -			: [vscode.Uri.parse('https://github.com/login/oauth')];
@@ -90,36 +104,87 @@ Index: product-integrator/lib/vscode/extensions/github-authentication/src/github
 +		const disposables: vscode.Disposable[] = [
  			this._telemetryReporter,
 -			vscode.authentication.registerAuthenticationProvider(
--				type,
--				this._githubServer.friendlyName,
--				this,
--				{
--					supportsMultipleAccounts: true,
--					supportedAuthorizationServers
--				}
--			),
- 			this.context.secrets.onDidChange(() => {
- 				if (this._sessionsPromise) {
- 					void this.checkForUpdates();
- 				}
- 			})
--		);
++			this.context.secrets.onDidChange(() => {
++				if (this._sessionsPromise) {
++					void this.checkForUpdates();
++				}
++			})
 +		];
 +
 +		if (registerAsAuthenticationProvider) {
 +			const supportedAuthorizationServers = ghesUri
 +				? [vscode.Uri.joinPath(ghesUri, '/login/oauth')]
 +				: [vscode.Uri.parse('https://github.com/login/oauth')];
-+			disposables.push(vscode.authentication.registerAuthenticationProvider(type, this._githubServer.friendlyName, this, {
-+				supportsMultipleAccounts: true,
-+				supportedAuthorizationServers
-+			}));
++			disposables.push(vscode.authentication.registerAuthenticationProvider(
+ 				type,
+ 				this._githubServer.friendlyName,
+ 				this,
+@@ -184,9 +186,10 @@
+ 					supportsMultipleAccounts: true,
+ 					supportedAuthorizationServers
+ 				}
+-			),
+-			this.context.secrets.onDidChange(() => this.checkForUpdates())
+-		);
++			));
 +		}
 +
 +		this._disposable = vscode.Disposable.from(...disposables);
  	}
  
  	dispose() {
+@@ -197,11 +200,23 @@
+ 		return this._sessionChangeEmitter.event;
+ 	}
+ 
++	private ensureSessionsLoaded(): Promise<vscode.AuthenticationSession[]> {
++		if (!this._sessionsPromise) {
++			this._sessionsPromise = this.readSessions().then((sessions) => {
++				// Delay keychain access until GitHub auth is explicitly requested so product startup does not prompt macOS for credentials.
++				setTimeout(() => sessions.forEach(s => this.afterSessionLoad(s)), 1000);
++				return sessions;
++			});
++		}
++
++		return this._sessionsPromise;
++	}
++
+ 	async getSessions(scopes: string[] | undefined, options?: vscode.AuthenticationProviderSessionOptions): Promise<vscode.AuthenticationSession[]> {
+ 		// For GitHub scope list, order doesn't matter so we immediately sort the scopes
+ 		const sortedScopes = scopes?.sort() || [];
+ 		this._logger.info(`Getting sessions for ${sortedScopes.length ? sortedScopes.join(',') : 'all scopes'}...`);
+-		const sessions = await this._sessionsPromise;
++		const sessions = await this.ensureSessionsLoaded();
+ 		const accountFilteredSessions = options?.account
+ 			? sessions.filter(session => session.account.label === options.account?.label)
+ 			: sessions;
+@@ -222,7 +237,7 @@
+ 	}
+ 
+ 	private async checkForUpdates() {
+-		const previousSessions = await this._sessionsPromise;
++		const previousSessions = await this.ensureSessionsLoaded();
+ 		this._sessionsPromise = this.readSessions();
+ 		const storedSessions = await this._sessionsPromise;
+ 
+@@ -363,7 +378,7 @@
+ 			if (options && !isGitHubAuthenticationProviderOptions(options)) {
+ 				throw new Error('Invalid options');
+ 			}
+-			const sessions = await this._sessionsPromise;
++			const sessions = await this.ensureSessionsLoaded();
+ 			const loginWith = options?.account?.label;
+ 			const signInProvider = options?.provider;
+ 			this._logger.info(`Logging in with${signInProvider ? ` ${signInProvider}, ` : ''} '${loginWith ? loginWith : 'any'}' account...`);
+@@ -426,7 +441,7 @@
+ 
+ 			this._logger.info(`Logging out of ${id}`);
+ 
+-			const sessions = await this._sessionsPromise;
++			const sessions = await this.ensureSessionsLoaded();
+ 			const sessionIndex = sessions.findIndex(session => session.id === id);
+ 			if (sessionIndex > -1) {
+ 				const session = sessions[sessionIndex];
 Index: product-integrator/lib/vscode/extensions/github-authentication/src/lazyAuthenticationProvider.ts
 ===================================================================
 --- /dev/null
@@ -170,84 +235,3 @@ Index: product-integrator/lib/vscode/extensions/github-authentication/src/lazyAu
 +		this._sessionChangeEmitter.dispose();
 +	}
 +}
-Index: product-integrator/lib/vscode/extensions/github-authentication/src/test/lazyAuthenticationProvider.test.ts
-===================================================================
---- /dev/null
-+++ product-integrator/lib/vscode/extensions/github-authentication/src/test/lazyAuthenticationProvider.test.ts
-@@ -0,0 +1,76 @@
-+/*---------------------------------------------------------------------------------------------
-+ *  Copyright (c) Microsoft Corporation. All rights reserved.
-+ *  Licensed under the MIT License. See License.txt in the project root for license information.
-+ *--------------------------------------------------------------------------------------------*/
-+
-+import * as assert from 'assert';
-+import * as vscode from 'vscode';
-+import { LazyAuthenticationProvider } from '../lazyAuthenticationProvider';
-+
-+class TestAuthenticationProvider implements vscode.AuthenticationProvider, vscode.Disposable {
-+	private readonly _sessionChangeEmitter = new vscode.EventEmitter<vscode.AuthenticationProviderAuthenticationSessionsChangeEvent>();
-+	private readonly sessions: vscode.AuthenticationSession[] = [];
-+	public readonly onDidChangeSessions = this._sessionChangeEmitter.event;
-+	public getSessionsCalls = 0;
-+
-+	getSessions(): Thenable<vscode.AuthenticationSession[]> {
-+		this.getSessionsCalls++;
-+		return Promise.resolve(this.sessions);
-+	}
-+
-+	createSession(): Thenable<vscode.AuthenticationSession> {
-+		throw new Error('not implemented');
-+	}
-+
-+	removeSession(): Thenable<void> {
-+		throw new Error('not implemented');
-+	}
-+
-+	fireChange(event: vscode.AuthenticationProviderAuthenticationSessionsChangeEvent): void {
-+		this._sessionChangeEmitter.fire(event);
-+	}
-+
-+	dispose(): void {
-+		this._sessionChangeEmitter.dispose();
-+	}
-+}
-+
-+suite('LazyAuthenticationProvider', () => {
-+	test('does not construct the real provider until a session method is called', async () => {
-+		let factoryCalls = 0;
-+		const provider = new TestAuthenticationProvider();
-+		const lazyProvider = new LazyAuthenticationProvider(() => {
-+			factoryCalls++;
-+			return provider;
-+		});
-+
-+		assert.strictEqual(factoryCalls, 0);
-+
-+		await lazyProvider.getSessions();
-+
-+		assert.strictEqual(factoryCalls, 1);
-+		assert.strictEqual(provider.getSessionsCalls, 1);
-+	});
-+
-+	test('forwards session change events after the real provider is materialized', async () => {
-+		const provider = new TestAuthenticationProvider();
-+		const lazyProvider = new LazyAuthenticationProvider(() => provider);
-+		let forwardedEvent: vscode.AuthenticationProviderAuthenticationSessionsChangeEvent | undefined;
-+
-+		lazyProvider.onDidChangeSessions(event => {
-+			forwardedEvent = event;
-+		});
-+
-+		await lazyProvider.getSessions();
-+
-+		const expectedEvent = {
-+			added: [],
-+			removed: [],
-+			changed: []
-+		};
-+
-+		provider.fireChange(expectedEvent);
-+
-+		assert.deepStrictEqual(forwardedEvent, expectedEvent);
-+	});
-+});

--- a/patches/series
+++ b/patches/series
@@ -14,3 +14,4 @@ disableWorkspaceTrust.diff
 disableThirdPartyExtNotifications.diff
 injectEnvs.diff
 integratorMenus.diff
+lazyGithubAuthStartup.diff


### PR DESCRIPTION
## Summary

Two patches in `patches/` were never applied in CI, causing latent failures whenever the built-in extensions or TypeScript cache missed:

- **`disableVsixChecksumCheck.diff`**: `fromVsix()` in `lib/vscode/build/lib/extensions.ts` throws a checksum mismatch error when `sha256` is `undefined`. Local VSIXs (like `wso2-integrator`) have no expected hash in `product.json`. The extensions cache key includes `wi/**`, so any `wi/` change busts the cache and exposes the error.

- **`increaseHeap.diff`**: `core-ci-pr` and `extensions-ci` OOM at Node's default heap limit (~1.5 GB) during full TypeScript compilation. The patch raises it to 8 GB via `--max-old-space-size`.

Both patches target `lib/vscode/` and are applied with `patch -p3` from the job's default `working-directory: lib/vscode`.

## Why it wasn't caught sooner

The CI passes on `main` because the caches stay warm between routine commits. Any PR that changes `wi/` files will bust both caches and hit these failures on a cold run.

## Test plan

- [ ] Trigger a CI run with a cold cache (or verify the patch step runs cleanly)
- [ ] Confirm `Install builtin extensions` and `Compile` steps pass