### PR TITLE
Add workflow tree elements to WSO2-Integrator extension

### DIFF
--- a/wi/wi-extension/package.json
+++ b/wi/wi-extension/package.json
@@ -335,6 +335,18 @@
         "title": "Add Custom Connector",
         "icon": "$(add)",
         "category": "WSO2 Integrator"
+      },
+      {
+        "command": "BI.project-explorer.add-workflow",
+        "title": "Add Workflow",
+        "icon": "$(add)",
+        "category": "WSO2 Integrator"
+      },
+      {
+        "command": "BI.project-explorer.add-workflow-activity",
+        "title": "Add Workflow Activity",
+        "icon": "$(add)",
+        "category": "WSO2 Integrator"
       }
     ],
     "menus": {
@@ -397,6 +409,14 @@
         },
         {
           "command": "BI.project-explorer.add-custom-connector",
+          "when": "false"
+        },
+        {
+          "command": "BI.project-explorer.add-workflow",
+          "when": "false"
+        },
+        {
+          "command": "BI.project-explorer.add-workflow-activity",
           "when": "false"
         }
       ],

--- a/wi/wi-extension/package.json
+++ b/wi/wi-extension/package.json
@@ -418,7 +418,7 @@
         },
         {
           "command": "BI.project-explorer.delete",
-          "when": "view == wso2-integrator.explorer && viewItem == CONNECTION || viewItem == SERVICE || viewItem == FUNCTION || viewItem == AUTOMATION || viewItem == TYPE || viewItem == CONFIGURABLE || viewItem == DATA_MAPPER || viewItem == NP_FUNCTION || viewItem == localConnector",
+          "when": "view == wso2-integrator.explorer && viewItem == CONNECTION || viewItem == SERVICE || viewItem == FUNCTION || viewItem == AUTOMATION || viewItem == TYPE || viewItem == CONFIGURABLE || viewItem == DATA_MAPPER || viewItem == NP_FUNCTION || viewItem == localConnector || viewItem == WORKFLOW || viewItem == ACTIVITY",
           "group": "inline"
         },
         {
@@ -464,6 +464,16 @@
         {
           "command": "BI.project-explorer.add-custom-connector",
           "when": "view == wso2-integrator.explorer && viewItem == localConnectors",
+          "group": "inline"
+        },
+        {
+          "command": "BI.project-explorer.add-workflow",
+          "when": "view == wso2-integrator.explorer && viewItem == workflows",
+          "group": "inline"
+        },
+        {
+          "command": "BI.project-explorer.add-workflow-activity",
+          "when": "view == wso2-integrator.explorer && viewItem == workflowActivities",
           "group": "inline"
         }
       ],

--- a/wi/wi-extension/src/bi/project-explorer/project-explorer-provider.ts
+++ b/wi/wi-extension/src/bi/project-explorer/project-explorer-provider.ts
@@ -433,6 +433,34 @@ function getEntriesBI(project: ProjectStructure): ProjectExplorerEntry[] {
     }
     entries.push(dataMappers);
 
+    // ---------- Workflows ----------
+    const workflowChildren = getComponents(project.directoryMap[DIRECTORY_MAP.WORKFLOW] ?? [], DIRECTORY_MAP.WORKFLOW, projectPath);
+    const workflows = new ProjectExplorerEntry(
+        'Workflows',
+        workflowChildren.length > 0 ? vscode.TreeItemCollapsibleState.Expanded : vscode.TreeItemCollapsibleState.Collapsed,
+        null,
+        'workflow',
+        false
+    );
+    workflows.resourceUri = Uri.parse(`bi-category:${projectPath}`);
+    workflows.contextValue = 'workflows';
+    workflows.children = workflowChildren;
+    entries.push(workflows);
+
+    // ---------- Workflow Activities ----------
+    const activityChildren = getComponents(project.directoryMap[DIRECTORY_MAP.ACTIVITY] ?? [], DIRECTORY_MAP.ACTIVITY, projectPath);
+    const workflowActivities = new ProjectExplorerEntry(
+        'Workflow Activities',
+        activityChildren.length > 0 ? vscode.TreeItemCollapsibleState.Expanded : vscode.TreeItemCollapsibleState.Collapsed,
+        null,
+        'task',
+        false
+    );
+    workflowActivities.resourceUri = Uri.parse(`bi-category:${projectPath}`);
+    workflowActivities.contextValue = 'workflowActivities';
+    workflowActivities.children = activityChildren;
+    entries.push(workflowActivities);
+
     // ---------- Configurations ----------
     const configs = new ProjectExplorerEntry(
         'Configurations',

--- a/wi/wi-extension/src/bi/types.ts
+++ b/wi/wi-extension/src/bi/types.ts
@@ -30,6 +30,10 @@ export const BI_COMMANDS = {
     REFRESH_COMMAND: 'BI.project-explorer.refresh',
     PROJECT_EXPLORER: 'BI.project-explorer',
     SHOW_OVERVIEW: 'BI.project-explorer.overview',
+    ADD_DATA_MAPPER: 'BI.project-explorer.add-data-mapper',
+    ADD_NATURAL_FUNCTION: 'BI.project-explorer.add-natural-function',
+    ADD_WORKFLOW: 'BI.project-explorer.add-workflow',
+    ADD_WORKFLOW_ACTIVITY: 'BI.project-explorer.add-workflow-activity',
     NOTIFY_PROJECT_EXPLORER: 'BI.project-explorer.notify',
 };
 
@@ -51,6 +55,8 @@ export enum DIRECTORY_MAP {
     CONNECTOR = 'CONNECTOR',
     RESOURCE = 'RESOURCE',
     REMOTE = 'REMOTE',
+    WORKFLOW = 'WORKFLOW',
+    ACTIVITY = 'ACTIVITY',
 }
 
 export enum MACHINE_VIEW {


### PR DESCRIPTION
## Purpose

Adds workflow and workflow activity tree elements to the WI extension project explorer.

## Changes

* Add workflow and workflow activity tree elements to wi-extension
* Add workflow commands to BI_COMMANDS and always show workflow tree items
* Register add-workflow and add-workflow-activity commands in package.json
* Add WORKFLOW and ACTIVITY to DIRECTORY_MAP enum

This is a subset of changes from #1331, containing only the first 3 workflow-related commits.