### PR TITLE
Fix delete command when clause operator precedence

### DIFF
--- a/wi/wi-extension/package.json
+++ b/wi/wi-extension/package.json
@@ -418,7 +418,7 @@
         },
         {
           "command": "BI.project-explorer.delete",
-          "when": "view == wso2-integrator.explorer && viewItem == CONNECTION || viewItem == SERVICE || viewItem == FUNCTION || viewItem == AUTOMATION || viewItem == TYPE || viewItem == CONFIGURABLE || viewItem == DATA_MAPPER || viewItem == NP_FUNCTION || viewItem == localConnector",
+          "when": "view == wso2-integrator.explorer && (viewItem == CONNECTION || viewItem == SERVICE || viewItem == FUNCTION || viewItem == AUTOMATION || viewItem == TYPE || viewItem == CONFIGURABLE || viewItem == DATA_MAPPER || viewItem == NP_FUNCTION || viewItem == localConnector)",
           "group": "inline"
         },
         {


### PR DESCRIPTION
## Purpose

Fixes the `when` clause for the `BI.project-explorer.delete` command in `wi/wi-extension/package.json`.

## Problem

The `when` clause uses `||` without parentheses, causing incorrect operator precedence:

```
view == wso2-integrator.explorer && viewItem == CONNECTION || viewItem == SERVICE || ...
```

This evaluates as `(view == ... && viewItem == CONNECTION) || viewItem == SERVICE || ...`, meaning the delete command shows in **any view** when the viewItem matches, not just in the integrator explorer.

## Fix

Wrap the `||` conditions in parentheses:

```
view == wso2-integrator.explorer && (viewItem == CONNECTION || viewItem == SERVICE || ...)
```

This ensures the delete command only appears in the `wso2-integrator.explorer` view.