### PR TITLE
feat: add workflow tree view icons

### DIFF
--- a/wi/wi-extension/assets/dark-workflow.svg
+++ b/wi/wi-extension/assets/dark-workflow.svg
@@ -1,0 +1,24 @@
+<!--
+ ~ Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ ~
+ ~ WSO2 LLC. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied. See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <g fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+        <rect width="8" height="8" x="3" y="3" rx="2"/>
+        <path d="M7 11v4a2 2 0 0 0 2 2h4"/>
+        <rect width="8" height="8" x="13" y="13" rx="2"/>
+    </g>
+</svg>

--- a/wi/wi-extension/assets/light-workflow.svg
+++ b/wi/wi-extension/assets/light-workflow.svg
@@ -1,0 +1,24 @@
+<!--
+ ~ Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ ~
+ ~ WSO2 LLC. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied. See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <g fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+        <rect width="8" height="8" x="3" y="3" rx="2"/>
+        <path d="M7 11v4a2 2 0 0 0 2 2h4"/>
+        <rect width="8" height="8" x="13" y="13" rx="2"/>
+    </g>
+</svg>


### PR DESCRIPTION
## Summary
- Add custom workflow SVG icons for tree view display
- Icons used for workflow category folder and individual workflow items

## Changes
- `wi/wi-extension/assets/light-workflow.svg` - Light theme workflow icon
- `wi/wi-extension/assets/dark-workflow.svg` - Dark theme workflow icon

## Impact
Workflow items in the tree view now display proper workflow icons instead of missing/generic icons. Works in conjunction with the icon mapping changes in vscode-extensions repo.