### PR TITLE
Update icp version to 2.0.0-beta2

### DIFF
--- a/ci/build/component-versions.properties
+++ b/ci/build/component-versions.properties
@@ -1,6 +1,6 @@
 integrator.version=5.0.0-beta6
 ballerina.version=2201.13.4-beta
-icp.version=2.0.0-beta
+icp.version=2.0.0-beta2
 ballerina.extension.version=5.9.4-260506-0603
 ballerina.jre.version=3.0.2
 wso2.hurl-client.extension.version=0.9.4


### PR DESCRIPTION
## Summary
- Update `icp.version` from `2.0.0-beta` to `2.0.0-beta2` in `ci/build/component-versions.properties`

## Test plan
- [ ] Verify CI build picks up the updated ICP version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ICP version from 2.0.0-beta to 2.0.0-beta2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->