### PR TITLE
Make Editor Reference Consistent Across the Application by Replacing VS Code Mentions

### DIFF
--- a/wi/wi-extension/package.json
+++ b/wi/wi-extension/package.json
@@ -145,12 +145,12 @@
       },
       {
         "view": "wso2-integrator.explorer",
-        "contents": "Welcome to WSO2 Integrator.\n\nYour current Ballerina distribution is not supported. Please update to version 2201.12.3 or above to continue.\n\n[Update Ballerina](command:wso2.integrator.setupBallerinaVisually)\n\nAfter updating, restart VS Code to apply the changes. [Learn more](https://wso2.github.io/docs-integrator/)",
+        "contents": "Welcome to WSO2 Integrator.\n\nYour current Ballerina distribution is not supported. Please update to version 2201.12.3 or above to continue.\n\n[Update Ballerina](command:wso2.integrator.setupBallerinaVisually)\n\nAfter updating, restart the editor to apply the changes. [Learn more](https://wso2.github.io/docs-integrator/)",
         "when": "(!WI.projectType || (WI.projectType != 'si' && WI.projectType != 'mi' && WI.projectType != 'none')) && BI.status == 'updateNeed'"
       },
       {
         "view": "wso2-integrator.explorer",
-        "contents": "Welcome to WSO2 Integrator.\n\nA Ballerina distribution is required but was not found on this machine. Please set up Ballerina to get started.\n\n[Set Up Ballerina](command:wso2.integrator.setupBallerinaVisually)\n\nAfter installation, restart VS Code to apply the changes. [Learn more](https://wso2.github.io/docs-integrator/)",
+        "contents": "Welcome to WSO2 Integrator.\n\nA Ballerina distribution is required but was not found on this machine. Please set up Ballerina to get started.\n\n[Set Up Ballerina](command:wso2.integrator.setupBallerinaVisually)\n\nAfter installation, restart the editor to apply the changes. [Learn more](https://wso2.github.io/docs-integrator/)",
         "when": "(!WI.projectType || (WI.projectType != 'si' && WI.projectType != 'mi' && WI.projectType != 'none')) && BI.status == 'noLS'"
       }
     ],

--- a/wi/wi-extension/src/cloud/activate.ts
+++ b/wi/wi-extension/src/cloud/activate.ts
@@ -115,7 +115,7 @@ function registerPreInitHandlers(): void {
 			affectsConfiguration("integrator.advanced.cloudRpcPath")
 		) {
 			const selection = await window.showInformationMessage(
-				"WSO2 Integrator extension configuration changed. Please restart VS Code for changes to take effect.",
+				"WSO2 Integrator extension configuration changed. Please restart the editor for changes to take effect.",
 				"Restart Now",
 			);
 			if (selection === "Restart Now") {

--- a/wi/wi-extension/src/cloud/auth/wso2-auth-provider.ts
+++ b/wi/wi-extension/src/cloud/auth/wso2-auth-provider.ts
@@ -137,7 +137,7 @@ export class WSO2AuthenticationProvider implements AuthenticationProvider, Dispo
 
 	/**
 	 * Create a new auth session by triggering the sign-in flow
-	 * This is called when user clicks "Sign in" in VS Code's Accounts menu
+	 * This is called when user clicks "Sign in" in the Editor Accounts menu
 	 */
 	public async createSession(scopes: string[], options?: AuthenticationProviderSessionOptions): Promise<AuthenticationSession> {
 		console.log("Creating new auth session via the Editor Accounts menu");

--- a/wi/wi-extension/src/cloud/auth/wso2-auth-provider.ts
+++ b/wi/wi-extension/src/cloud/auth/wso2-auth-provider.ts
@@ -140,7 +140,7 @@ export class WSO2AuthenticationProvider implements AuthenticationProvider, Dispo
 	 * This is called when user clicks "Sign in" in VS Code's Accounts menu
 	 */
 	public async createSession(scopes: string[], options?: AuthenticationProviderSessionOptions): Promise<AuthenticationSession> {
-		console.log("Creating new auth session via VS Code Accounts menu");
+		console.log("Creating new auth session via the Editor Accounts menu");
 		const customOptions = options as any;
 		const platform = customOptions?.platform;
 

--- a/wi/wi-webviews/src/views/ImportIntegration/MigrationProgressView.tsx
+++ b/wi/wi-webviews/src/views/ImportIntegration/MigrationProgressView.tsx
@@ -189,7 +189,7 @@ export function MigrationProgressView({
                                     text: isMultiProject ? "Open Workspace" : "Open Project",
                                     onClick: onOpenProject,
                                     disabled: true,
-                                    tooltip: `Opening ${projects.length} projects simultaneously may cause VS Code to become unresponsive. Navigate to the destination path to open them manually.`,
+                                    tooltip: `Opening ${projects.length} projects simultaneously may cause the editor to become unresponsive. Navigate to the destination path to open them manually.`,
                                 }}
                             />
                         ) : (

--- a/wi/wi-webviews/src/views/ImportIntegration/WizardAIEnhancementView.tsx
+++ b/wi/wi-webviews/src/views/ImportIntegration/WizardAIEnhancementView.tsx
@@ -1033,7 +1033,7 @@ export function WizardAIEnhancementView({ wsClient, projectCount, isMultiProject
                         isRunning
                             ? "AI enhancement is in progress. Pause first to open the project."
                             : openProjectDisabled
-                                ? `Opening ${projectCount} projects simultaneously may cause VS Code to become unresponsive. Navigate to the destination path to open them manually.`
+                                ? `Opening ${projectCount} projects simultaneously may cause the editor to become unresponsive. Navigate to the destination path to open them manually.`
                                 : undefined
                     }
                 >

--- a/wi/wi-webviews/src/views/setup/BallerinaView.tsx
+++ b/wi/wi-webviews/src/views/setup/BallerinaView.tsx
@@ -164,9 +164,9 @@ export function SetupBallerinaView() {
                                 {progress?.success && (
                                     <SuccessSection>
                                         <StepTitle>Setup complete</StepTitle>
-                                        <StepDesc>Restart VS Code to finish applying the changes.</StepDesc>
+                                        <StepDesc>Restart the editor to finish applying the changes.</StepDesc>
                                         <div style={{ marginTop: "4px" }}>
-                                            <Button appearance="primary" onClick={handleRestart}>Restart VS Code</Button>
+                                            <Button appearance="primary" onClick={handleRestart}>Restart Editor</Button>
                                         </div>
                                     </SuccessSection>
                                 )}

--- a/wi/wi-webviews/src/views/setup/CompactContent.tsx
+++ b/wi/wi-webviews/src/views/setup/CompactContent.tsx
@@ -178,9 +178,9 @@ export function SetupContent() {
             {progress?.success && (
                 <CompactSuccessSection>
                     <StepTitle>Setup complete</StepTitle>
-                    <StepDesc>Restart VS Code to finish applying the changes.</StepDesc>
+                    <StepDesc>Restart the editor to finish applying the changes.</StepDesc>
                     <div style={{ marginTop: "4px" }}>
-                        <Button appearance="primary" onClick={handleRestart}>Restart VS Code</Button>
+                        <Button appearance="primary" onClick={handleRestart}>Restart Editor</Button>
                     </div>
                 </CompactSuccessSection>
             )}

--- a/wi/wi-webviews/src/views/setup/shared.tsx
+++ b/wi/wi-webviews/src/views/setup/shared.tsx
@@ -39,7 +39,7 @@ export const STEPS = [
     { title: "Install Ballerina Tool", description: "Downloading and installing the Ballerina tool package." },
     { title: "Install Ballerina Distribution", description: "Downloading and installing the Ballerina distribution package." },
     { title: "Install Java Runtime", description: "Downloading and installing the required Java Runtime Environment." },
-    { title: "Complete Setup", description: "Configuring VS Code, setting permissions and finalizing installation." },
+    { title: "Complete Setup", description: "Setting permissions and finalizing installation." },
 ];
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Purpose
$title

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated UI messages and button labels to refer to "the editor" instead of "VS Code" for consistency.
  * Refined setup completion prompts and dialog tooltips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->