### PR TITLE
fix: add tooltip to truncated sample card titles in prebuild samples view

### DIFF
--- a/wi/wi-webviews/src/views/samplesView/SamplesContainer.tsx
+++ b/wi/wi-webviews/src/views/samplesView/SamplesContainer.tsx
@@ -873,7 +873,17 @@ export function SamplesContainer(props: SamplesContainerProps) {
 						{filteredItems.map((item) => (
 							<SampleCard key={item.id} className="sample-card">
 								<CardHeader>
-									<Tooltip content={item.title}>
+									<Tooltip
+										content={item.title}
+										position="bottom"
+										offset={{ top: 16, left: 20 }}
+										sx={{
+											maxWidth: "280px",
+											whiteSpace: "normal",
+											wordWrap: "break-word",
+											overflowWrap: "break-word",
+										}}
+									>
 										<CardTitle>{item.title}</CardTitle>
 									</Tooltip>
 									<CategoryLabel>{item.componentType}</CategoryLabel>

--- a/wi/wi-webviews/src/views/samplesView/SamplesContainer.tsx
+++ b/wi/wi-webviews/src/views/samplesView/SamplesContainer.tsx
@@ -18,7 +18,7 @@
 
 import styled from "@emotion/styled";
 import { VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react";
-import { Button, Codicon, Dropdown, SearchBox } from "@wso2/ui-toolkit";
+import { Button, Codicon, Dropdown, SearchBox, Tooltip } from "@wso2/ui-toolkit";
 import {
 	GettingStartedCategory,
 	SampleItem,
@@ -873,7 +873,9 @@ export function SamplesContainer(props: SamplesContainerProps) {
 						{filteredItems.map((item) => (
 							<SampleCard key={item.id} className="sample-card">
 								<CardHeader>
-									<CardTitle>{item.title}</CardTitle>
+									<Tooltip content={item.title}>
+										<CardTitle>{item.title}</CardTitle>
+									</Tooltip>
 									<CategoryLabel>{item.componentType}</CategoryLabel>
 								</CardHeader>
 								<IconFrame>


### PR DESCRIPTION
## Summary

- Wrap the `CardTitle` element in the prebuild samples list with `<Tooltip content={item.title}>` from `@wso2/ui-toolkit`
- Add `Tooltip` to the existing `@wso2/ui-toolkit` import in `SamplesContainer.tsx`

The `CardTitle` uses `-webkit-line-clamp: 2` to cap titles at two lines. Long titles are silently cut off with `…` and users had no way to read the full text. The tooltip appears on hover and shows the complete title.

Fixes #679

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sample titles now display helpful tooltips on hover, showing the complete title text for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->