### PR TITLE
ci: bump wso2ipw to 0.1.6

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -108,7 +108,7 @@ jobs:
           node-version: '20'
 
       - name: Install wso2ipw
-        run: npm install -g wso2ipw@0.1.5
+        run: npm install -g wso2ipw@0.1.6
 
       - name: Install playwright-cli and Chrome
         if: matrix.example == 'icp'
@@ -207,7 +207,7 @@ jobs:
           node-version: '20'
 
       - name: Install wso2ipw
-        run: npm install -g wso2ipw@0.1.5
+        run: npm install -g wso2ipw@0.1.6
 
       - name: Install playwright-cli and Chrome
         if: matrix.example == 'icp'


### PR DESCRIPTION
Bump `wso2ipw` from 0.1.5 to 0.1.6 in smoke-test workflow (both Linux and Windows).

## What's in 0.1.6

Fixes a race condition in the Return node save step where only "Saving" was awaited but not the subsequent "Validating" phase. On slower CI runners, clicking the HelloWorld breadcrumb during validation is silently ignored, causing `Timeout waiting for text: Design`.

**Failed run:** https://github.com/wso2/product-integrator/actions/runs/25630090494/job/75288318512

**Fix PR:** https://github.com/manuranga/wso2ipw/pull/2

> **Note:** This PR depends on wso2ipw 0.1.6 being published to npm first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing workflow dependency to v0.1.6 for improved test environment consistency across Linux and Windows platforms.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/product-integrator/pull/1462)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->