### PR TITLE
Update Ballerina extension versions to v5.12.0

### DIFF
--- a/ci/build/component-versions.properties
+++ b/ci/build/component-versions.properties
@@ -1,7 +1,7 @@
 integrator.version=5.0.0
 ballerina.version=2201.13.4
 icp.version=2.0.0
-ballerina.extension.version=5.11.26051510
+ballerina.extension.version=5.12.0
 ballerina.jre.version=3.0.2
 wso2.hurl-client.extension.version=0.9.4
 wso2.mcp-server-inspector.extension.version=0.7.4


### PR DESCRIPTION
### Purpose 

This PR updates the WSO2 Integrator app with the latest release versions (v5.12.0) of the Ballerina extension.