### PR TITLE
Fix ICP installer permissions with ACL masks

### DIFF
--- a/installers/linux-deb/package/DEBIAN/postinst
+++ b/installers/linux-deb/package/DEBIAN/postinst
@@ -3,10 +3,10 @@
 # Copyright (c) WSO2. All rights reserved.
 # Change ownership and permissions for integrator files
 chown -R root:root /usr/share/wso2-integrator
-chmod -R o+w /usr/share/wso2-integrator/components/icp/bin/database/
+chmod -R a+rwX /usr/share/wso2-integrator/components/icp/bin/database/
 mkdir -p /usr/share/wso2-integrator/components/icp/logs
-chmod -R o+rwx /usr/share/wso2-integrator/components/icp/logs/
-chmod o+w /usr/share/wso2-integrator/components/icp/www/config.json 2>/dev/null || true
+chmod -R a+rwX /usr/share/wso2-integrator/components/icp/logs/
+chmod a+rw /usr/share/wso2-integrator/components/icp/www/config.json 2>/dev/null || true
 chmod 4755 /usr/share/wso2-integrator/chrome-sandbox 2>/dev/null || true
 
 # Create symlinks to /usr/bin

--- a/installers/linux-rpm/wso2-integrator.spec
+++ b/installers/linux-rpm/wso2-integrator.spec
@@ -65,10 +65,10 @@ rm -rf %{buildroot}
 %post
 # Change ownership and permissions for integrator files
 chown -R root:root /usr/share/wso2-integrator
-chmod -R o+w /usr/share/wso2-integrator/components/icp/bin/database/ 2>/dev/null || true
+chmod -R a+rwX /usr/share/wso2-integrator/components/icp/bin/database/ 2>/dev/null || true
 mkdir -p /usr/share/wso2-integrator/components/icp/logs
-chmod -R o+rwx /usr/share/wso2-integrator/components/icp/logs/
-chmod o+w /usr/share/wso2-integrator/components/icp/www/config.json 2>/dev/null || true
+chmod -R a+rwX /usr/share/wso2-integrator/components/icp/logs/
+chmod a+rw /usr/share/wso2-integrator/components/icp/www/config.json 2>/dev/null || true
 chmod 4755 /usr/share/wso2-integrator/chrome-sandbox 2>/dev/null || true
 
 # Create symlink to /usr/bin


### PR DESCRIPTION
## Purpose
Fix Linux ICP startup failures when installed files have ACL entries for the runtime user.

## Details
PR #1515 used `o+w` / `o+rwx`, but named ACL entries can take precedence over `other` permissions. In GitHub Actions the installed ICP database files had `runner` ACL entries with an ACL mask that removed write permission, so H2 opened the DB read-only and rejected `AUTO_SERVER=TRUE`.

Use `a+rwX` / `a+rw` so chmod also updates ACL masks and makes the ICP database, logs, and config writable for the runtime user.

## Validation
Tested on the manuranga fork using the failed upstream DEB artifact from run 25906411194.

- Failure reproduced with original permissions: https://github.com/manuranga/product-integrator/actions/runs/25926929520
- Candidate fix passed ICP smoke test: https://github.com/manuranga/product-integrator/actions/runs/25927113456

Original failing upstream job: https://github.com/wso2/product-integrator/actions/runs/25906411194/job/76145282922

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated permission handling for integrator components in Linux installer packages (DEB and RPM) to improve accessibility and compatibility during installation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/product-integrator/pull/1560)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->