### PR TITLE
Skip integration type picker for safe combos + create context.yaml early

### DIFF
--- a/wi/wi-extension/src/cloud/cloud-ext-api.ts
+++ b/wi/wi-extension/src/cloud/cloud-ext-api.ts
@@ -63,7 +63,7 @@ export class WICloudExtensionAPI implements IWso2PlatformExtensionAPI {
 
 	// Git
 	public localRepoHasChanges = (fsPath: string): Promise<boolean> =>
-		hasDirtyRepo(fsPath, ext.context, ["context.yaml"]);
+		hasDirtyRepo(fsPath, ext.context);
 
 	// Navigation
 	public openClonedDir = (params: Parameters<IWso2PlatformExtensionAPI["openClonedDir"]>[0]): Promise<void> =>

--- a/wi/wi-extension/src/cloud/cmds/commit-and-push-to-git-cmd.ts
+++ b/wi/wi-extension/src/cloud/cmds/commit-and-push-to-git-cmd.ts
@@ -82,7 +82,7 @@ export function commitAndPushToGitCommand(context: ExtensionContext) {
 						throw new Error(`Failed to select ${ext.terminologies?.componentTerm} to be pushed to remote`);
 					}
 
-					const haveChanges = await hasDirtyRepo(selectedComp.componentFsPath, ext.context, ["context.yaml"]);
+					const haveChanges = await hasDirtyRepo(selectedComp.componentFsPath, ext.context);
 					if (!haveChanges) {
 						window.showErrorMessage("There are no new changes to push to cloud");
 						return;

--- a/wi/wi-extension/src/cloud/cmds/create-component-cmd.ts
+++ b/wi/wi-extension/src/cloud/cmds/create-component-cmd.ts
@@ -219,6 +219,13 @@ export function createNewComponentCommand(context: ExtensionContext) {
 					}
 
 					if (isWithinWorkspace || workspace.workspaceFile) {
+						// Update context.yaml file when opening the integration creation form
+						if (gitRoot || params?.workspaceDir) {
+							const projectCache = dataCacheStore.getState().getProjects(selectedOrg?.handle);
+							updateContextFile(gitRoot || params?.workspaceDir, ext.authProvider?.getState().state.userInfo!, selectedProject, selectedOrg, projectCache);
+							contextStore.getState().refreshState();
+						}
+
 						openCloudFormWebview({
 							org: selectedOrg,
 							project: selectedProject,

--- a/wi/wi-extension/src/ws-managers/cloud/ws-manager.ts
+++ b/wi/wi-extension/src/ws-managers/cloud/ws-manager.ts
@@ -158,7 +158,7 @@ export class CloudWsManager implements Omit<WICloudAPI, "onAuthStateChanged" | "
 	}
 
 	async hasDirtyRepo(dirPath: string): Promise<boolean> {
-		return checkDirtyRepo(dirPath, ext.context, ["context.yaml"]);
+		return checkDirtyRepo(dirPath, ext.context);
 	}
 
 	async getConfigFileDrifts(params: GetConfigFileDriftsReq): Promise<string[]> {

--- a/wi/wi-webviews/src/views/componentFormView/ComponentFormView.tsx
+++ b/wi/wi-webviews/src/views/componentFormView/ComponentFormView.tsx
@@ -19,7 +19,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Button, ProgressIndicator, Typography } from "@wso2/ui-toolkit";
 import { GetGitMetadataResp, type WICloudFormContext, type WICloudSubmitComponentsReq } from "@wso2/wi-core";
-import { buildGitURL, type CreateComponentReq, DevantScopes, getTypeOfIntegrationType, type ICreateNewIntegrationCmdIntegrations, makeURLSafe, WICommandIds } from "@wso2/wso2-platform-core";
+import { buildGitURL, type CreateComponentReq, DevantScopes, getTypeOfIntegrationType, type ICreateNewIntegrationCmdIntegrations, makeURLSafe, resolveIntegrationType, WICommandIds } from "@wso2/wso2-platform-core";
 import { useVisualizerContext } from "../../contexts";
 import { useCloudContext } from "../../providers";
 import {
@@ -41,11 +41,16 @@ import { RepoInitSection, type RepoInitData } from "./RepoInitSection";
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
 function initEntryState(entry: ICreateNewIntegrationCmdIntegrations): EntryFormState {
+	const resolution = resolveIntegrationType(entry.supportedIntegrationTypes ?? []);
+	const initialScope =
+		resolution.kind === "autoPick" || resolution.kind === "autoPickWithWarning"
+			? resolution.scope
+			: entry.supportedIntegrationTypes?.[0];
 	return {
 		displayName: entry.name,
 		selected: true,
 		fsPath: entry.fsPath,
-		selectedIntegrationType: entry.supportedIntegrationTypes?.[0],
+		selectedIntegrationType: initialScope,
 	};
 }
 

--- a/wi/wi-webviews/src/views/componentFormView/ComponentList.tsx
+++ b/wi/wi-webviews/src/views/componentFormView/ComponentList.tsx
@@ -18,7 +18,7 @@
 
 import React from "react";
 import { CheckBox } from "@wso2/ui-toolkit";
-import { DevantScopes, getIntegrationScopeText, ICreateNewIntegrationCmdIntegrations, Project } from "@wso2/wso2-platform-core";
+import { AUTOMATION_WITH_LISTENER_WARNING, DevantScopes, getIntegrationScopeText, ICreateNewIntegrationCmdIntegrations, Project, resolveIntegrationType } from "@wso2/wso2-platform-core";
 import {
 	CheckboxCell,
 	ComponentInfo,
@@ -109,89 +109,102 @@ export function ComponentList({
 					const isLast = index === integrations.length - 1;
 					const isLibrary = entry.supportedIntegrationTypes?.includes(DevantScopes.LIBRARY) ?? false;
 
+					const resolution = resolveIntegrationType(entry.supportedIntegrationTypes ?? []);
+					const showAutomationWarning = resolution.kind === "autoPickWithWarning";
+
 					return (
 						<ComponentListRow
 							key={entry.fsPath}
 							isSelected={isSelected}
 							isLast={isLast}
+							style={{ flexDirection: "column", alignItems: "stretch", gap: 0 }}
 						>
-							{/* Checkbox — shown for all entries in batch; always shown for libraries (locked) */}
-							{(isBatch || isLibrary) && (
-								<CheckboxCell>
-									<CheckBox
-										label=""
-										checked={isSelected}
-										disabled={isLibrary}
-										onChange={(checked: boolean) => onToggle(index, checked)}
-									/>
-								</CheckboxCell>
-							)}
-
-							{/* Name + directory */}
-							<ComponentInfo>
-								{isEditing && isSelected ? (
-									<NameInputWrapper>
-										<NameInput
-											hasError={!!nameError}
-											value={currentName}
-											autoFocus
-											spellCheck={false}
-											onChange={(e) => onNameChange(index, e.target.value)}
-											onBlur={onNameCommit}
-											onKeyDown={(e) => {
-												if (e.key === "Enter" || e.key === "Escape") {
-													onNameCommit();
-												}
-											}}
+							<div style={{ display: "flex", alignItems: "flex-start", gap: 14 }}>
+								{/* Checkbox — shown for all entries in batch; always shown for libraries (locked) */}
+								{(isBatch || isLibrary) && (
+									<CheckboxCell>
+										<CheckBox
+											label=""
+											checked={isSelected}
+											disabled={isLibrary}
+											onChange={(checked: boolean) => onToggle(index, checked)}
 										/>
-										{nameError && <NameError>{nameError}</NameError>}
-									</NameInputWrapper>
-								) : isSelected ? (
-									<NameButton
-										type="button"
-										title={nameError ?? "Click to edit name"}
-										onClick={() => onEditStart(index)}
-									>
-										<span>{currentName}</span>
-										{nameError && <span style={{ color: "var(--vscode-errorForeground)", fontSize: 11 }}>⚠</span>}
-										<span className="edit-icon" aria-hidden>✎</span>
-									</NameButton>
-								) : (
-									<NameStatic>{currentName}</NameStatic>
+									</CheckboxCell>
 								)}
 
-								<DirPath title={entry.fsPath}>
-									<span aria-hidden>⊞</span>
-									<span className="path-text">{entry.fsPath}</span>
-								</DirPath>
-							</ComponentInfo>
-
-							{/* Type badge */}
-							{entry.supportedIntegrationTypes?.length > 0 && (
-								<TypeBadge isSelected={isSelected}>
-									{entry.supportedIntegrationTypes.length === 1 ? (
-										<span>{getIntegrationScopeText(entry.supportedIntegrationTypes[0])}</span>
-									) : (
-										<select
-											value={state?.selectedIntegrationType ?? ""}
-											onChange={(e) => onIntegrationTypeChange(index, e.target.value)}
-											style={{
-												background: "transparent",
-												border: "none",
-												color: "inherit",
-												font: "inherit",
-												fontSize: "inherit",
-												cursor: "pointer",
-												outline: "none",
-												padding: 0,
-											}}
+								{/* Name + directory */}
+								<ComponentInfo>
+									{isEditing && isSelected ? (
+										<NameInputWrapper>
+											<NameInput
+												hasError={!!nameError}
+												value={currentName}
+												autoFocus
+												spellCheck={false}
+												onChange={(e) => onNameChange(index, e.target.value)}
+												onBlur={onNameCommit}
+												onKeyDown={(e) => {
+													if (e.key === "Enter" || e.key === "Escape") {
+														onNameCommit();
+													}
+												}}
+											/>
+											{nameError && <NameError>{nameError}</NameError>}
+										</NameInputWrapper>
+									) : isSelected ? (
+										<NameButton
+											type="button"
+											title={nameError ?? "Click to edit name"}
+											onClick={() => onEditStart(index)}
 										>
-											{entry.supportedIntegrationTypes.map((type) => (
-												<option key={type} value={type}>{getIntegrationScopeText(type)}</option>
-											))}
-										</select>
+											<span>{currentName}</span>
+											{nameError && <span style={{ color: "var(--vscode-errorForeground)", fontSize: 11 }}>⚠</span>}
+											<span className="edit-icon" aria-hidden>✎</span>
+										</NameButton>
+									) : (
+										<NameStatic>{currentName}</NameStatic>
 									)}
-								</TypeBadge>
+
+									<DirPath title={entry.fsPath}>
+										<span aria-hidden>⊞</span>
+										<span className="path-text">{entry.fsPath}</span>
+									</DirPath>
+								</ComponentInfo>
+
+								{/* Type badge — auto-picked label or ask-the-user dropdown */}
+								{entry.supportedIntegrationTypes?.length > 0 && (
+									<TypeBadge isSelected={isSelected}>
+										{resolution.kind === "ask" ? (
+											<select
+												value={state?.selectedIntegrationType ?? ""}
+												onChange={(e) => onIntegrationTypeChange(index, e.target.value)}
+												style={{
+													background: "transparent",
+													border: "none",
+													color: "inherit",
+													font: "inherit",
+													fontSize: "inherit",
+													cursor: "pointer",
+													outline: "none",
+													padding: 0,
+												}}
+											>
+												{resolution.choices.map((type) => (
+													<option key={type} value={type}>{getIntegrationScopeText(type)}</option>
+												))}
+											</select>
+										) : (
+											<span>{getIntegrationScopeText(resolution.scope)}</span>
+										)}
+									</TypeBadge>
+								)}
+							</div>
+
+							{/* Inline warning for AUTOMATION + listener combos */}
+							{showAutomationWarning && (
+								<WarningBanner style={{ marginTop: 10 }}>
+									⚠ {AUTOMATION_WITH_LISTENER_WARNING}
+								</WarningBanner>
 							)}
 						</ComponentListRow>
 					);


### PR DESCRIPTION
## Summary

Two related improvements to the integration creation flow:

### 1. Skip integration type picker for safe combinations

Fixes [wso2/product-integrator#1616](https://github.com/wso2/product-integrator/issues/1616). Pulls in the shared `resolveIntegrationType` helper from [wso2/vscode-extensions#2297](https://github.com/wso2/vscode-extensions/pull/2297) and applies it to the per-row picker in the WI Component form.

- **Service (`INTEGRATION_AS_API` / `AI_AGENT` / `MCP`) + listener(s):** the dropdown collapses to a label and the service is silently chosen. Listeners run regardless of the deployment type, so the picker added no real choice.
- **`AUTOMATION` + listener(s) (no service):** picker collapses to "Automation" with an inline warning banner explaining that the listener will run for the duration of every automation run.
- **Anything else:** unchanged — per-row dropdown shown as today.

### 2. Create `context.yaml` when the integration form opens

Move the `.wso2/context.yaml` write from "after the component is created in the cloud" to "when the user opens the integration creation form." This makes it much more likely the user commits the context file to their git repo alongside the integration code, since it's already on disk by the time they make their initial commit. Also stops excluding `context.yaml` from dirty-repo checks since it is now expected to be a tracked file.

### Submodule bump

`external/wso2-vscode-extensions`: `43fb9dbde…` → `a395cbc4b…` (the merge commit of #2297 on `release/ballerina-5.12.x`). Pulls in:
- `resolveIntegrationType` helper + `AUTOMATION_WITH_LISTENER_WARNING` constant in `wso2-platform-core`.
- Matching picker-suppression logic in the Ballerina deploy paths (`rpc-manager.ts`, `activator.ts`).
- Two trivy security bumps (`qs` 6.14.2→6.15.2, `tmp` 0.2.4→0.2.6).

## Test plan

- [ ] Open integration creation form in a workspace with `INTEGRATION_AS_API` + `EVENT_INTEGRATION`: row shows "Integration as API" as a label, no dropdown.
- [ ] Open integration creation form with `AUTOMATION` + `EVENT_INTEGRATION`: row shows "Automation" as a label with an inline warning banner.
- [ ] Open integration creation form with two services (e.g. `INTEGRATION_AS_API` + `AI_AGENT`): dropdown still shown.
- [ ] Open integration creation form on a workspace without git initialized: form opens cleanly (no "path argument must be of type string" error), context update is skipped.
- [ ] Open integration creation form on a workspace with git initialized: `.wso2/context.yaml` is created/updated before the form is interacted with.
- [ ] Existing `commitAndPushToGit` flow: dirty-repo check correctly flags changes to `context.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added warning notification for automation scenarios with listeners.

* **Improvements**
  * Enhanced repository change detection to include all file modifications.
  * Improved integration type selection logic during component form initialization.
  * Context file now automatically updates when creating new cloud components.
  * Refined component list rendering to intelligently display integration type options based on resolution strategy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/product-integrator/pull/1627?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->