### PR TITLE
Fix viewing and downloading individual reports in multi-root mode

### DIFF
--- a/wi/wi-core/src/types/network-bridge.types.ts
+++ b/wi/wi-core/src/types/network-bridge.types.ts
@@ -53,6 +53,7 @@ import {
     SetWebviewCacheParams,
     ShowErrorMessageRequest,
     StoreSubProjectReportsRequest,
+    OpenSubProjectReportRequest,
     ValidateProjectFormRequest,
     ValidateProjectFormResponse,
     WebviewContext,
@@ -138,6 +139,7 @@ export interface WIWsMethodParamsMap {
     openMigrationReport: OpenMigrationReportRequest;
     saveMigrationReport: SaveMigrationReportRequest;
     storeSubProjectReports: StoreSubProjectReportsRequest;
+    openSubProjectReport: OpenSubProjectReportRequest;
     validateProjectPath: ValidateProjectFormRequest;
     openFolder: string;
     openExternal: string;
@@ -209,6 +211,7 @@ export interface WIWsMethodResultMap {
     openMigrationReport: void;
     saveMigrationReport: void;
     storeSubProjectReports: void;
+    openSubProjectReport: void;
     validateProjectPath: ValidateProjectFormResponse;
     openFolder: void;
     openExternal: void;

--- a/wi/wi-core/src/types/webview-api.types.ts
+++ b/wi/wi-core/src/types/webview-api.types.ts
@@ -285,6 +285,10 @@ export interface StoreSubProjectReportsRequest {
     reports: { [projectName: string]: string };
 }
 
+export interface OpenSubProjectReportRequest {
+    projectName: string;
+}
+
 export interface FetchSamplesRequest {
     runtime?: "WSO2: BI" | "WSO2: MI" | "WSO2: SI";
 }

--- a/wi/wi-extension/src/BridgeLayer.ts
+++ b/wi/wi-extension/src/BridgeLayer.ts
@@ -42,6 +42,7 @@ import {
     SetWebviewCacheParams,
     ShowErrorMessageRequest,
     StoreSubProjectReportsRequest,
+    OpenSubProjectReportRequest,
     ValidateProjectFormRequest,
     WI_BRIDGE_EVENTS,
     WIBridgeRequest,
@@ -354,6 +355,9 @@ export class BridgeLayer {
         );
         registerRoute("storeSubProjectReports", async (request) =>
             wsManager.storeSubProjectReports(request.params as StoreSubProjectReportsRequest)
+        );
+        registerRoute("openSubProjectReport", async (request) =>
+            wsManager.openSubProjectReport(request.params as OpenSubProjectReportRequest)
         );
         registerRoute("validateProjectPath", async (request) =>
             wsManager.validateProjectPath(request.params as ValidateProjectFormRequest)

--- a/wi/wi-extension/src/migration-report/webview.ts
+++ b/wi/wi-extension/src/migration-report/webview.ts
@@ -24,30 +24,116 @@ export class MigrationReportWebview {
     public static currentPanel: MigrationReportWebview | undefined;
     private _panel: WebviewPanel;
     private _disposables: Disposable[] = [];
+    private _onOpenSubProjectReport?: (projectName: string) => void;
+    private _onGoHome?: () => void;
+    /** Scroll-Y to restore once the next page signals it is ready */
+    private _pendingScrollY: number = 0;
+    /** Scroll-Y of the aggregate report, saved when a sub-project is opened */
+    private _aggregateScrollY: number = 0;
 
-    private constructor(panel: WebviewPanel, reportContent: string) {
+    private constructor(
+        panel: WebviewPanel,
+        reportContent: string,
+        showHomeButton: boolean,
+        onOpenSubProjectReport?: (projectName: string) => void,
+        onGoHome?: () => void
+    ) {
         this._panel = panel;
+        this._onOpenSubProjectReport = onOpenSubProjectReport;
+        this._onGoHome = onGoHome;
         this._panel.onDidDispose(() => this.dispose(), null, this._disposables);
 
-        const htmlWithStyleRemoval = reportContent.replace(
-            "</head>",
-            `<script>
-                document.addEventListener('DOMContentLoaded', function() {
-                    const defaultStyles = document.getElementById('_defaultStyles');
-                    if (defaultStyles) {
-                        defaultStyles.remove();
-                    }
-                });
-            </script></head>`
-        );
+        this._panel.webview.html = this._buildHtml(reportContent, showHomeButton);
 
-        this._panel.webview.html = htmlWithStyleRemoval;
+        this._panel.webview.onDidReceiveMessage(
+            (message) => {
+                if (message.type === 'pageReady') {
+                    // Page has loaded; send the scroll position now that Chromium is done restoring
+                    this._panel.webview.postMessage({ type: 'scrollTo', y: this._pendingScrollY });
+                } else if (message.type === 'openSubProjectReport') {
+                    if (/^[\w\-]+$/.test(message.projectName)) {
+                        // Save aggregate scroll before navigating away
+                        this._aggregateScrollY = typeof message.scrollY === 'number' ? message.scrollY : 0;
+                        this._onOpenSubProjectReport?.(message.projectName);
+                    }
+                } else if (message.type === 'goHome') {
+                    this._onGoHome?.();
+                }
+            },
+            null,
+            this._disposables
+        );
     }
 
-    public static createOrShow(fileName: string, reportContent: string): void {
+    private _buildHtml(reportContent: string, showHomeButton: boolean): string {
+        const homeBar = showHomeButton
+            ? `<div id="wi-home-bar" style="position:fixed;top:0;left:0;right:0;z-index:9999;display:flex;align-items:center;padding:6px 12px;background:var(--vscode-editor-background,#1e1e1e);border-bottom:1px solid var(--vscode-panel-border,#454545);font-family:var(--vscode-font-family,sans-serif);">
+                <button id="wi-home-btn" style="display:flex;align-items:center;gap:6px;padding:4px 12px;cursor:pointer;background:var(--vscode-button-secondaryBackground,#3a3d41);color:var(--vscode-button-secondaryForeground,#ccc);border:1px solid var(--vscode-button-border,transparent);border-radius:3px;font-size:13px;">
+                    &#8592; Back to Aggregate Report
+                </button>
+               </div>
+               <div style="height:40px;"></div>`
+            : '';
+
+        const withHomeBar = homeBar
+            ? reportContent.replace(/(<body[^>]*>)/i, `$1${homeBar}`)
+            : reportContent;
+
+        return withHomeBar.replace(
+            "</head>",
+            `<script>
+                (function() {
+                    const vscode = acquireVsCodeApi();
+
+                    // Extension will tell us where to scroll once the page is ready
+                    window.addEventListener('message', function(event) {
+                        if (event.data && event.data.type === 'scrollTo') {
+                            window.scrollTo(0, event.data.y || 0);
+                        }
+                    });
+
+                    document.addEventListener('DOMContentLoaded', function() {
+                        // Signal to extension that Chromium has finished loading/restoring scroll
+                        vscode.postMessage({ type: 'pageReady' });
+
+                        const defaultStyles = document.getElementById('_defaultStyles');
+                        if (defaultStyles) {
+                            defaultStyles.remove();
+                        }
+
+                        document.querySelectorAll('a.project-link').forEach(function(link) {
+                            link.addEventListener('click', function(event) {
+                                event.preventDefault();
+                                const projectName = link.id || link.textContent.trim();
+                                if (/^[\\w\\-]+$/.test(projectName)) {
+                                    // Include current scroll position so it can be restored later
+                                    vscode.postMessage({ type: 'openSubProjectReport', projectName: projectName, scrollY: window.scrollY });
+                                }
+                            });
+                        });
+
+                        const homeBtn = document.getElementById('wi-home-btn');
+                        if (homeBtn) {
+                            homeBtn.addEventListener('click', function() {
+                                vscode.postMessage({ type: 'goHome' });
+                            });
+                        }
+                    });
+                })();
+            </script></head>`
+        );
+    }
+
+    public static createOrShow(
+        fileName: string,
+        reportContent: string,
+        showHomeButton: boolean,
+        onOpenSubProjectReport?: (projectName: string) => void,
+        onGoHome?: () => void
+    ): void {
         if (MigrationReportWebview.currentPanel) {
             MigrationReportWebview.currentPanel._panel.reveal(ViewColumn.Active);
-            MigrationReportWebview.currentPanel.updateContent(reportContent);
+            MigrationReportWebview.currentPanel.updateContent(reportContent, showHomeButton, onOpenSubProjectReport, onGoHome);
             return;
         }
 
@@ -66,23 +152,20 @@ export class MigrationReportWebview {
             dark: Uri.file(path.join(ext.context.extensionPath, "resources", "icons", "dark-icon.svg")),
         };
 
-        MigrationReportWebview.currentPanel = new MigrationReportWebview(panel, reportContent);
+        MigrationReportWebview.currentPanel = new MigrationReportWebview(panel, reportContent, showHomeButton, onOpenSubProjectReport, onGoHome);
     }
 
-    private updateContent(reportContent: string): void {
-        const htmlWithStyleRemoval = reportContent.replace(
-            "</head>",
-            `<script>
-                document.addEventListener('DOMContentLoaded', function() {
-                    const defaultStyles = document.getElementById('_defaultStyles');
-                    if (defaultStyles) {
-                        defaultStyles.remove();
-                    }
-                });
-            </script></head>`
-        );
-
-        this._panel.webview.html = htmlWithStyleRemoval;
+    private updateContent(
+        reportContent: string,
+        showHomeButton: boolean,
+        onOpenSubProjectReport?: (projectName: string) => void,
+        onGoHome?: () => void
+    ): void {
+        this._onOpenSubProjectReport = onOpenSubProjectReport;
+        this._onGoHome = onGoHome;
+        // Sub-project reports always start at top (0); going back to aggregate restores its saved position
+        this._pendingScrollY = showHomeButton ? 0 : this._aggregateScrollY;
+        this._panel.webview.html = this._buildHtml(reportContent, showHomeButton);
     }
 
     public dispose(): void {

--- a/wi/wi-extension/src/ws-managers/main/ws-manager.ts
+++ b/wi/wi-extension/src/ws-managers/main/ws-manager.ts
@@ -71,7 +71,7 @@ import { BridgeLayer } from "../../BridgeLayer";
 import { OpenMigrationReportRequest, SaveMigrationReportRequest, PullMigrationToolRequest } from "@wso2/wi-core";
 import { StateMachine } from "../../stateMachine";
 import { ext } from "../../extensionVariables";
-import { StoreSubProjectReportsRequest } from "@wso2/wi-core";
+import { StoreSubProjectReportsRequest, OpenSubProjectReportRequest } from "@wso2/wi-core";
 import { ballerinaContext } from "../../bi/ballerinaContext";
 const platform = getPlatform();
 const SAMPLES_INFO_URL = process.env.SAMPLES_INFO_URL;
@@ -79,6 +79,7 @@ const PREBUILT_INTEGRATIONS_URL = process.env.PREBUILT_INTEGRATIONS_URL;
 
 export class MainWsManager implements WIVisualizerAPI {
     private subProjectReports: Map<string, string> = new Map();
+    private aggregateReport: string | undefined;
     constructor(private projectUri?: string) { }
 
     async getWebviewContext(): Promise<WebviewContext> {
@@ -608,25 +609,89 @@ export class MainWsManager implements WIVisualizerAPI {
     }
 
     async openMigrationReport(params: OpenMigrationReportRequest): Promise<void> {
-        MigrationReportWebview.createOrShow(params.fileName, params.reportContent);
+        this.aggregateReport = params.reportContent;
+        MigrationReportWebview.createOrShow(params.fileName, params.reportContent, false, (projectName: string) => {
+            this.openSubProjectReport({ projectName });
+        });
+    }
+
+    async openSubProjectReport(params: OpenSubProjectReportRequest): Promise<void> {
+        let reportContent = this.subProjectReports.get(params.projectName);
+
+        if (!reportContent) {
+            // Try prefix-match fallback for key variants like "projectName_ballerina"
+            const matchingKey = Array.from(this.subProjectReports.keys()).find(key =>
+                key === params.projectName || key.startsWith(params.projectName)
+            );
+            if (matchingKey) {
+                reportContent = this.subProjectReports.get(matchingKey);
+            }
+        }
+
+        if (!reportContent) {
+            const vscode = await import('vscode');
+            vscode.window.showErrorMessage(`Report for project '${params.projectName}' not found.`);
+            return;
+        }
+
+        MigrationReportWebview.createOrShow(
+            params.projectName,
+            reportContent,
+            true,
+            undefined,
+            () => {
+                if (this.aggregateReport) {
+                    MigrationReportWebview.createOrShow('aggregate_dry_run_report', this.aggregateReport, false, (projectName: string) => {
+                        this.openSubProjectReport({ projectName });
+                    });
+                }
+            }
+        );
     }
 
     async saveMigrationReport(params: SaveMigrationReportRequest): Promise<void> {
         const vscode = await import('vscode');
+        const hasSubReports = params.projectReports && Object.keys(params.projectReports).length > 0;
 
-        // Show save dialog
-        const saveUri = await vscode.window.showSaveDialog({
-            defaultUri: vscode.Uri.file(params.defaultFileName),
-            filters: {
-                'HTML files': ['html'],
-                'All files': ['*']
+        if (hasSubReports) {
+            // For multi-project: show folder picker and save all reports inside it
+            const folderUri = await vscode.window.showOpenDialog({
+                canSelectFiles: false,
+                canSelectFolders: true,
+                canSelectMany: false,
+                openLabel: 'Save Reports Here',
+            });
+
+            if (folderUri && folderUri[0]) {
+                const folder = folderUri[0];
+                await vscode.workspace.fs.writeFile(
+                    vscode.Uri.joinPath(folder, 'aggregate_dry_run_report.html'),
+                    Buffer.from(params.reportContent, 'utf8')
+                );
+                for (const [projectName, reportContent] of Object.entries(params.projectReports!)) {
+                    const projectDir = vscode.Uri.joinPath(folder, projectName);
+                    await vscode.workspace.fs.createDirectory(projectDir);
+                    await vscode.workspace.fs.writeFile(
+                        vscode.Uri.joinPath(projectDir, 'migration_report.html'),
+                        Buffer.from(reportContent, 'utf8')
+                    );
+                }
+                vscode.window.showInformationMessage(`Migration reports saved to ${folder.fsPath}`);
             }
-        });
+        } else {
+            // Single-project: show file save dialog
+            const saveUri = await vscode.window.showSaveDialog({
+                defaultUri: vscode.Uri.file(params.defaultFileName),
+                filters: {
+                    'HTML files': ['html'],
+                    'All files': ['*']
+                }
+            });
 
-        if (saveUri) {
-            // Write the report content to the selected file
-            await vscode.workspace.fs.writeFile(saveUri, Buffer.from(params.reportContent, 'utf8'));
-            vscode.window.showInformationMessage(`Migration report saved to ${saveUri.fsPath}`);
+            if (saveUri) {
+                await vscode.workspace.fs.writeFile(saveUri, Buffer.from(params.reportContent, 'utf8'));
+                vscode.window.showInformationMessage(`Migration report saved to ${saveUri.fsPath}`);
+            }
         }
     }
 

--- a/wi/wi-extension/src/ws-managers/main/ws-manager.ts
+++ b/wi/wi-extension/src/ws-managers/main/ws-manager.ts
@@ -629,8 +629,7 @@ export class MainWsManager implements WIVisualizerAPI {
         }
 
         if (!reportContent) {
-            const vscode = await import('vscode');
-            vscode.window.showErrorMessage(`Report for project '${params.projectName}' not found.`);
+            window.showErrorMessage(`Report for project '${params.projectName}' not found.`);
             return;
         }
 
@@ -650,12 +649,11 @@ export class MainWsManager implements WIVisualizerAPI {
     }
 
     async saveMigrationReport(params: SaveMigrationReportRequest): Promise<void> {
-        const vscode = await import('vscode');
         const hasSubReports = params.projectReports && Object.keys(params.projectReports).length > 0;
 
         if (hasSubReports) {
             // For multi-project: show folder picker and save all reports inside it
-            const folderUri = await vscode.window.showOpenDialog({
+            const folderUri = await window.showOpenDialog({
                 canSelectFiles: false,
                 canSelectFolders: true,
                 canSelectMany: false,
@@ -664,24 +662,24 @@ export class MainWsManager implements WIVisualizerAPI {
 
             if (folderUri && folderUri[0]) {
                 const folder = folderUri[0];
-                await vscode.workspace.fs.writeFile(
-                    vscode.Uri.joinPath(folder, 'aggregate_dry_run_report.html'),
+                await workspace.fs.writeFile(
+                    Uri.joinPath(folder, 'aggregate_dry_run_report.html'),
                     Buffer.from(params.reportContent, 'utf8')
                 );
                 for (const [projectName, reportContent] of Object.entries(params.projectReports!)) {
-                    const projectDir = vscode.Uri.joinPath(folder, projectName);
-                    await vscode.workspace.fs.createDirectory(projectDir);
-                    await vscode.workspace.fs.writeFile(
-                        vscode.Uri.joinPath(projectDir, 'migration_report.html'),
+                    const projectDir = Uri.joinPath(folder, projectName);
+                    await workspace.fs.createDirectory(projectDir);
+                    await workspace.fs.writeFile(
+                        Uri.joinPath(projectDir, 'migration_report.html'),
                         Buffer.from(reportContent, 'utf8')
                     );
                 }
-                vscode.window.showInformationMessage(`Migration reports saved to ${folder.fsPath}`);
+                window.showInformationMessage(`Migration reports saved to ${folder.fsPath}`);
             }
         } else {
             // Single-project: show file save dialog
-            const saveUri = await vscode.window.showSaveDialog({
-                defaultUri: vscode.Uri.file(params.defaultFileName),
+            const saveUri = await window.showSaveDialog({
+                defaultUri: Uri.file(params.defaultFileName),
                 filters: {
                     'HTML files': ['html'],
                     'All files': ['*']
@@ -689,8 +687,8 @@ export class MainWsManager implements WIVisualizerAPI {
             });
 
             if (saveUri) {
-                await vscode.workspace.fs.writeFile(saveUri, Buffer.from(params.reportContent, 'utf8'));
-                vscode.window.showInformationMessage(`Migration report saved to ${saveUri.fsPath}`);
+                await workspace.fs.writeFile(saveUri, Buffer.from(params.reportContent, 'utf8'));
+                window.showInformationMessage(`Migration report saved to ${saveUri.fsPath}`);
             }
         }
     }

--- a/wi/wi-webviews/src/views/ImportIntegration/ImportIntegrationForm.tsx
+++ b/wi/wi-webviews/src/views/ImportIntegration/ImportIntegrationForm.tsx
@@ -149,7 +149,7 @@ export function ImportIntegrationForm({
                 This wizard converts external integration projects from MuleSoft or TIBCO into new WSO2 integrator projects, accelerating the migration process.
             </BodyText>
             <Typography variant="h3" sx={{ marginTop: 20 }}>
-                Choose the source platform
+                Choose the Source Platform
             </Typography>
             <BodyText>Select the integration platform that your current project uses:</BodyText>
             {integrationSelectionError && (

--- a/wi/wi-webviews/src/views/ImportIntegration/MigrationProgressView.tsx
+++ b/wi/wi-webviews/src/views/ImportIntegration/MigrationProgressView.tsx
@@ -173,7 +173,7 @@ export function MigrationProgressView({
                             <RadioOption selected={!aiEnhancementEnabled} onClick={() => setAiEnhancementEnabled(false)}>
                                 <RadioInput type="radio" name="ai-enhancement-mode-report" checked={!aiEnhancementEnabled} onChange={() => setAiEnhancementEnabled(false)} />
                                 <RadioContent>
-                                    <RadioTitle>Skip for Now – Enhance Later</RadioTitle>
+                                    <RadioTitle>Skip for Now, Enhance Later</RadioTitle>
                                     <RadioDescription>Keep the project as-is. You can trigger AI enhancement later from the WSO2 Integrator Copilot.</RadioDescription>
                                 </RadioContent>
                             </RadioOption>

--- a/wi/wi-webviews/src/views/ImportIntegration/WizardAIEnhancementView.tsx
+++ b/wi/wi-webviews/src/views/ImportIntegration/WizardAIEnhancementView.tsx
@@ -717,7 +717,7 @@ export function WizardAIEnhancementView({ wsClient, projectCount, isMultiProject
                     <>
                         <div style={{ display: "flex", alignItems: "center", gap: "6px" }}>
                             <SpinnerIcon className="codicon codicon-sync" />
-                            <StatusText variant="running">AI Enhancement in progress…</StatusText>
+                            <StatusText variant="running">AI enhancement in progress…</StatusText>
                             <span style={{ fontSize: "11px", color: "var(--vscode-descriptionForeground)", fontVariantNumeric: "tabular-nums" }}>
                                 [{formatElapsed(elapsed)}]
                             </span>

--- a/wi/wi-webviews/src/views/ImportIntegration/index.tsx
+++ b/wi/wi-webviews/src/views/ImportIntegration/index.tsx
@@ -77,9 +77,7 @@ export function ImportIntegration({ onBack }: { onBack?: () => void }) {
     // Routes migration tool events to the correct run's state
     const activeRunRef = useRef<"dryRun" | "migration" | null>(null);
 
-    const defaultSteps = aiEnhancementActive
-        ? ["Configure Source", "Report Generation", "Configure Destination", "Rule-Based Migration", "AI Enhancement"]
-        : ["Configure Source", "Report Generation", "Configure Destination", "Rule-Based Migration"];
+    const defaultSteps = ["Configure Source", "Report Generation", "Configure Destination", "Rule-Based Migration", "AI Enhancement"];
 
     // isMultiProject for ConfigureProjectForm is derived from the source config (step 0 selection)
     const boolParamKey = selectedIntegration?.parameters.find(p => p.valueType === "boolean")?.key;


### PR DESCRIPTION
## Purpose
$subject. 

Fixes #1618

## Samples

https://github.com/user-attachments/assets/0de8dbd7-9efa-4fc4-9e8c-4f9b9ae4346e


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Navigate between aggregate and sub-project migration reports from the report view
  * Restore scroll position when switching reports; “Back to Aggregate Report” home button added
  * Multi-project migrations save as a folder with per-project reports

* **Improvements**
  * Clarified UI text in import integration views
  * AI Enhancement step is now always shown in the migration wizard
<!-- end of auto-generated comment: release notes by coderabbit.ai -->