### PR TITLE
Fix missing logging view in dry-run and rule-based migration

### DIFF
--- a/wi/wi-extension/src/BridgeLayer.ts
+++ b/wi/wi-extension/src/BridgeLayer.ts
@@ -78,6 +78,7 @@ type RequestRouter = ReturnType<typeof createRequestRouter<WIBridgeRequest, WIBr
 interface BridgeChannel {
     transport: TransportManager;
     registration?: { dispose(): void };
+    wsManager: MainWsManager;
 }
 
 export class BridgeLayer {
@@ -190,6 +191,7 @@ export class BridgeLayer {
         if (!channel) {
             return;
         }
+        channel.wsManager.disposeMigrationListeners();
         channel.registration?.dispose();
         channel.transport.dispose();
         this.channels.delete(projectUri);
@@ -219,7 +221,7 @@ export class BridgeLayer {
             handleRequest: (request) => router.handle(request),
         });
 
-        const channel: BridgeChannel = { transport };
+        const channel: BridgeChannel = { transport, wsManager };
         this.channels.set(projectUri, channel);
 
         // Subscribe to cloud state changes and forward as bridge events

--- a/wi/wi-extension/src/ws-managers/main/ballerinaLogger.ts
+++ b/wi/wi-extension/src/ws-managers/main/ballerinaLogger.ts
@@ -44,7 +44,7 @@ async function getSharedOutputChannel(): Promise<vscode.OutputChannel | undefine
     pendingChannelPromise = (async () => {
         try {
             const ballerinaExt = await getActiveBallerinaExtension();
-            cachedOutputChannel = ballerinaExt.exports.getOutPutChannel();
+            cachedOutputChannel = ballerinaExt.exports.ballerinaExtInstance.getOutPutChannel();
             return cachedOutputChannel;
         } catch (err) {
             console.error('Failed to acquire shared Ballerina output channel', err);

--- a/wi/wi-extension/src/ws-managers/main/ws-manager.ts
+++ b/wi/wi-extension/src/ws-managers/main/ws-manager.ts
@@ -87,6 +87,16 @@ export class MainWsManager implements WIVisualizerAPI {
     private migratedProjectDisposable: { dispose(): void } | undefined;
     constructor(private projectUri?: string) { }
 
+    /** Dispose all active language-client migration notification subscriptions. */
+    disposeMigrationListeners(): void {
+        this.migrationToolStateDisposable?.dispose();
+        this.migrationToolStateDisposable = undefined;
+        this.migrationToolLogDisposable?.dispose();
+        this.migrationToolLogDisposable = undefined;
+        this.migratedProjectDisposable?.dispose();
+        this.migratedProjectDisposable = undefined;
+    }
+
     async getWebviewContext(): Promise<WebviewContext> {
         const context = StateMachine.getContext();
         return new Promise((resolve) => {
@@ -591,12 +601,12 @@ export class MainWsManager implements WIVisualizerAPI {
         }
 
         // Dispose any listeners from a previous run (e.g. dry-run) to prevent duplicate events.
-        this.migrationToolStateDisposable?.dispose();
-        this.migrationToolLogDisposable?.dispose();
-        this.migratedProjectDisposable?.dispose();
+        this.disposeMigrationListeners();
 
         // Forward language server streaming notifications to the WI webview via BridgeLayer.
-        const projectUri = StateMachine.getContext().projectUri ?? 'global';
+        // Use this.projectUri (the manager's own stable reference) rather than the global StateMachine
+        // context, which can change mid-migration if another wizard opens and mutates the context.
+        const projectUri = this.projectUri ?? 'global';
         this.migrationToolStateDisposable = langClient.onNotification('projectService/stateCallback', (res: any) => {
             try {
                 const stateData: MigrationToolStateData = typeof res === 'string' ? { state: res } : res;

--- a/wi/wi-extension/src/ws-managers/main/ws-manager.ts
+++ b/wi/wi-extension/src/ws-managers/main/ws-manager.ts
@@ -55,7 +55,9 @@ import {
     DefaultOrgNameResponse,
     SampleItem,
     BIRuntimeStatusResponse,
-    EXTENSION_DEPENDENCIES
+    EXTENSION_DEPENDENCIES,
+    MigrationToolStateData,
+    MigrationToolLogData
 } from "@wso2/wi-core";
 import { commands, extensions, window, workspace, MarkdownString, Uri, env, ConfigurationTarget } from "vscode";
 import { getActiveBallerinaExtension } from "../../utils/ballerinaExtension";
@@ -79,6 +81,10 @@ const PREBUILT_INTEGRATIONS_URL = process.env.PREBUILT_INTEGRATIONS_URL;
 
 export class MainWsManager implements WIVisualizerAPI {
     private subProjectReports: Map<string, string> = new Map();
+    private aggregateReport: string | undefined;
+    private migrationToolStateDisposable: { dispose(): void } | undefined;
+    private migrationToolLogDisposable: { dispose(): void } | undefined;
+    private migratedProjectDisposable: { dispose(): void } | undefined;
     constructor(private projectUri?: string) { }
 
     async getWebviewContext(): Promise<WebviewContext> {
@@ -578,11 +584,36 @@ export class MainWsManager implements WIVisualizerAPI {
             parameters: params.parameters,
         };
         const langClient = await this.getLangClient();
-        langClient.registerMigrationToolCallbacks();
+        try {
+            langClient.registerMigrationToolCallbacks();
+        } catch (err) {
+            console.error('[WI] registerMigrationToolCallbacks failed (non-fatal):', err);
+        }
 
-        // the WI webview receives onMigratedProject notifications as each project is migrated.
+        // Dispose any listeners from a previous run (e.g. dry-run) to prevent duplicate events.
+        this.migrationToolStateDisposable?.dispose();
+        this.migrationToolLogDisposable?.dispose();
+        this.migratedProjectDisposable?.dispose();
+
+        // Forward language server streaming notifications to the WI webview via BridgeLayer.
         const projectUri = StateMachine.getContext().projectUri ?? 'global';
-        langClient.onNotification('projectService/pushMigratedProject', (res: any) => {
+        this.migrationToolStateDisposable = langClient.onNotification('projectService/stateCallback', (res: any) => {
+            try {
+                const stateData: MigrationToolStateData = typeof res === 'string' ? { state: res } : res;
+                BridgeLayer.notifyMigrationToolStateChanged(projectUri, stateData);
+            } catch (error) {
+                console.error('[WI] Error forwarding migrationToolState notification:', error);
+            }
+        });
+        this.migrationToolLogDisposable = langClient.onNotification('projectService/logCallback', (res: any) => {
+            try {
+                const logData: MigrationToolLogData = typeof res === 'string' ? { log: res } : res;
+                BridgeLayer.notifyMigrationToolLogs(projectUri, logData);
+            } catch (error) {
+                console.error('[WI] Error forwarding migrationToolLog notification:', error);
+            }
+        });
+        this.migratedProjectDisposable = langClient.onNotification('projectService/pushMigratedProject', (res: any) => {
             try {
                 BridgeLayer.notifyMigratedProject(res, projectUri);
             } catch (error) {

--- a/wi/wi-webviews/src/views/ImportIntegration/DryRunView.tsx
+++ b/wi/wi-webviews/src/views/ImportIntegration/DryRunView.tsx
@@ -40,7 +40,7 @@ export function DryRunView({
     toolPullFailureMessage,
     migrationToolCommandName,
 }: DryRunViewProps) {
-    const [isLogsOpen, setIsLogsOpen] = useState(false);
+    const [isLogsOpen, setIsLogsOpen] = useState(true);
     const { wsClient } = useVisualizerContext();
 
     const parsedReportData = useMemo(() => {
@@ -57,10 +57,10 @@ export function DryRunView({
     }, [migrationResponse?.jsonReport]);
 
     useEffect(() => {
-        if (!migrationCompleted && migrationLogs.length > 0) {
-            setIsLogsOpen(true);
-        } else if (migrationCompleted) {
+        if (migrationCompleted) {
             setIsLogsOpen(false);
+        } else if (migrationLogs.length > 0) {
+            setIsLogsOpen(true);
         }
     }, [migrationCompleted, migrationLogs.length]);
 

--- a/wi/wi-webviews/src/views/ImportIntegration/MigrationProgressView.tsx
+++ b/wi/wi-webviews/src/views/ImportIntegration/MigrationProgressView.tsx
@@ -66,18 +66,15 @@ export function MigrationProgressView({
     toolPullFailureMessage,
     migrationToolCommandName,
 }: MigrationProgressProps) {
-    const [isLogsOpen, setIsLogsOpen] = useState(false);
+    const [isLogsOpen, setIsLogsOpen] = useState(true);
     const [aiEnhancementEnabled, setAiEnhancementEnabled] = useState(true);
     const { wsClient } = useVisualizerContext();
 
-    // Auto-open logs during migration and auto-collapse when completed
     useEffect(() => {
-        if (!migrationCompleted && migrationLogs.length > 0) {
-            // Migration is in progress and we have logs - open the dropdown
-            setIsLogsOpen(true);
-        } else if (migrationCompleted) {
-            // Migration is completed - collapse the dropdown
+        if (migrationCompleted) {
             setIsLogsOpen(false);
+        } else if (migrationLogs.length > 0) {
+            setIsLogsOpen(true);
         }
     }, [migrationCompleted, migrationLogs.length]);
 

--- a/wi/wi-webviews/src/views/ImportIntegration/components/MigrationLogs.tsx
+++ b/wi/wi-webviews/src/views/ImportIntegration/components/MigrationLogs.tsx
@@ -36,20 +36,21 @@ interface MigrationLogsProps {
 }
 
 const getColourizedLog = (log: string, index: number) => {
-    if (log.startsWith("[SEVERE]")) {
+    const logStr = typeof log === 'string' ? log : String(log ?? '');
+    if (logStr.startsWith("[SEVERE]")) {
         return (
             <LogEntry key={index} style={{ color: "var(--vscode-terminal-ansiRed)" }}>
-                {log}
+                {logStr}
             </LogEntry>
         );
-    } else if (log.startsWith("[WARN]")) {
+    } else if (logStr.startsWith("[WARN]")) {
         return (
             <LogEntry key={index} style={{ color: "var(--vscode-terminal-ansiYellow)" }}>
-                {log}
+                {logStr}
             </LogEntry>
         );
     }
-    return <LogEntry key={index}>{log}</LogEntry>;
+    return <LogEntry key={index}>{logStr}</LogEntry>;
 };
 
 export const MigrationLogs: React.FC<MigrationLogsProps> = ({
@@ -74,7 +75,7 @@ export const MigrationLogs: React.FC<MigrationLogsProps> = ({
 
     return (
         <StepWrapper>
-            {/* Only show header when migration is completed and showHeader is true */}
+            {/* Only show header after migration completes and showHeader is enabled */}
             {migrationCompleted && showHeader && (
                 <CollapsibleHeader onClick={onToggleLogs}>
                     <Typography variant="h4">View Detailed Logs</Typography>
@@ -83,7 +84,7 @@ export const MigrationLogs: React.FC<MigrationLogsProps> = ({
                     </CardAction>
                 </CollapsibleHeader>
             )}
-            {/* Show logs container when open OR when migration is in progress OR when showHeader is false */}
+            {/* Always show container during migration; toggleable after completion */}
             {(isLogsOpen || !migrationCompleted || !showHeader) && (
                 <LogsContainer ref={logsContainerRef}>
                     {migrationLogs.map(getColourizedLog)}

--- a/wi/wi-webviews/src/views/ImportIntegration/components/MigrationStatusContent.tsx
+++ b/wi/wi-webviews/src/views/ImportIntegration/components/MigrationStatusContent.tsx
@@ -78,7 +78,7 @@ export const MigrationStatusContent: React.FC<MigrationStatusContentProps> = ({
     if (state.isFailed) {
         return (
             <ErrorBanner variant="body3" sx={{ color: "var(--vscode-errorForeground)" }}>
-                Migration error: {migrationResponse.error}
+                Migration error: {migrationResponse?.error ?? 'An unknown error occurred'}
             </ErrorBanner>
         );
     }

--- a/wi/wi-webviews/src/views/ImportIntegration/index.tsx
+++ b/wi/wi-webviews/src/views/ImportIntegration/index.tsx
@@ -118,6 +118,7 @@ export function ImportIntegration({ onBack }: { onBack?: () => void }) {
             console.error("Error during dry run:", error);
             setDryRunCompleted(true);
             setDryRunSuccessful(false);
+            setDryRunResponse({ error: error instanceof Error ? error.message : String(error), textEdits: {}, report: '', jsonReport: '' });
         }
     };
 
@@ -149,6 +150,7 @@ export function ImportIntegration({ onBack }: { onBack?: () => void }) {
             console.error("Error during migration:", error);
             setMigrationCompleted(true);
             setMigrationSuccessful(false);
+            setMigrationResponse({ error: error instanceof Error ? error.message : String(error), textEdits: {}, report: '', jsonReport: '' });
         }
     };
 


### PR DESCRIPTION
## Purpose
$subject.

Fixes #1482

## Samples

Loggings are now visible

https://github.com/user-attachments/assets/c4ae4608-4f81-4c9a-b736-095d97b3d2a3



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent duplicate migration notifications by properly disposing prior listeners.
  * Ensure migration errors and dry-run failures are captured and shown.
  * Robust log processing to avoid rendering crashes from unexpected log values.

* **Improvements**
  * Migration logs panel opens by default and auto-closes when migration completes.
  * More resilient failure messages and consistent setting of response state on exceptions.
  * Logging now uses a consistent shared output channel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->