### PR TITLE
Fix VSCode Workspace Reload Opening Wrong Folder In Cloud Editor

### DIFF
--- a/wi/wi-extension/package.json
+++ b/wi/wi-extension/package.json
@@ -518,6 +518,7 @@
     "compile": "webpack --mode development",
     "compile-tests": "tsc -p . --outDir out",
     "test": "node ./out/test/runTest.js",
+    "test:unit": "npm run compile-tests && ./node_modules/.bin/mocha out/test/utils/uriUtils.test.js",
     "package": "node ../../external/wso2-vscode-extensions/workspaces/common-libs/scripts/package-vsix.js",
     "download-choreo-cli": "node scripts/download-choreo-cli.js"
   },

--- a/wi/wi-extension/src/cloud/cmds/create-component-cmd.ts
+++ b/wi/wi-extension/src/cloud/cmds/create-component-cmd.ts
@@ -534,7 +534,18 @@ async function updateCodeServerWithCreatedComp(
 const showReloadWorkspaceMessage = (message: string, workspaceFsPath: string) => {
 	window.showInformationMessage(`${message} Reload workspace to continue`, { modal: true }, "Continue").then(async (resp) => {
 		if (resp === "Continue") {
-			commands.executeCommand("vscode.openFolder", Uri.file(workspaceFsPath), { forceNewWindow: false });
+			// In VS Code Remote (cloud editor), workspace folder URIs carry a remote authority
+			// (e.g. vscode-remote://ssh-remote+host/path). Using Uri.file() would produce a
+			// file:// URI with no authority, causing VS Code to open the folder on the local
+			// client rather than the remote — resulting in the wrong workspace root.
+			// We preserve the existing workspace URI's scheme and authority so the folder
+			// is opened correctly on the remote, falling back to Uri.file() when there is
+			// no current workspace (e.g. fresh local session).
+			const existingWorkspaceUri = workspace.workspaceFolders?.[0]?.uri;
+			const folderUri = existingWorkspaceUri
+				? existingWorkspaceUri.with({ path: workspaceFsPath })
+				: Uri.file(workspaceFsPath);
+			commands.executeCommand("vscode.openFolder", folderUri, { forceNewWindow: false });
 		}
 	});
 }

--- a/wi/wi-extension/src/cloud/cmds/create-component-cmd.ts
+++ b/wi/wi-extension/src/cloud/cmds/create-component-cmd.ts
@@ -40,6 +40,7 @@ import { getGitRemotes, getGitRoot, relativePath } from "../git/util";
 import { contextStore, waitForContextStoreToLoad } from "../stores/context-store";
 import { dataCacheStore } from "../stores/data-cache-store";
 import { isSamePath, isSubpath } from "../../utils/pathUtils";
+import { buildRemoteAwareUri } from "../../utils/uriUtils";
 import { getUserInfoForCmd, isRpcActive, selectOrg, selectProjectWithCreateNew, setExtensionName } from "./cmd-utils";
 import { updateContextFile } from "./create-directory-context-cmd";
 import { WICloudSubmitComponentsReq, WICloudSubmitComponentsResp } from "@wso2/wi-core";
@@ -534,17 +535,11 @@ async function updateCodeServerWithCreatedComp(
 const showReloadWorkspaceMessage = (message: string, workspaceFsPath: string) => {
 	window.showInformationMessage(`${message} Reload workspace to continue`, { modal: true }, "Continue").then(async (resp) => {
 		if (resp === "Continue") {
-			// In VS Code Remote (cloud editor), workspace folder URIs carry a remote authority
-			// (e.g. vscode-remote://ssh-remote+host/path). Using Uri.file() would produce a
-			// file:// URI with no authority, causing VS Code to open the folder on the local
-			// client rather than the remote — resulting in the wrong workspace root.
-			// We preserve the existing workspace URI's scheme and authority so the folder
-			// is opened correctly on the remote, falling back to Uri.file() when there is
-			// no current workspace (e.g. fresh local session).
 			const existingWorkspaceUri = workspace.workspaceFolders?.[0]?.uri;
-			const folderUri = existingWorkspaceUri
-				? existingWorkspaceUri.with({ path: workspaceFsPath })
-				: Uri.file(workspaceFsPath);
+			ext.log(`[openFolder] existingWorkspaceUri: ${existingWorkspaceUri?.toString() ?? "none"}`);
+			ext.log(`[openFolder] targetPath: ${workspaceFsPath}`);
+			const folderUri = buildRemoteAwareUri(workspaceFsPath, existingWorkspaceUri, (p) => Uri.file(p));
+			ext.log(`[openFolder] resolved folderUri: ${folderUri.toString()}`);
 			commands.executeCommand("vscode.openFolder", folderUri, { forceNewWindow: false });
 		}
 	});

--- a/wi/wi-extension/src/test/utils/uriUtils.test.ts
+++ b/wi/wi-extension/src/test/utils/uriUtils.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Unit tests for buildRemoteAwareUri.
+ * No VS Code dependency — runs with plain Node.js + mocha.
+ */
+
+import * as assert from "assert";
+import { buildRemoteAwareUri, UriLike } from "../../utils/uriUtils";
+
+function makeUri(scheme: string, authority: string, uriPath: string): UriLike {
+    return {
+        scheme,
+        authority,
+        path: uriPath,
+        with(change: { path: string }): UriLike {
+            return makeUri(this.scheme, this.authority, change.path);
+        },
+        toString(): string {
+            return authority ? `${scheme}://${authority}${uriPath}` : `${scheme}://${uriPath}`;
+        },
+    };
+}
+
+const fakeFileUriFactory = (p: string): UriLike => makeUri("file", "", p);
+
+describe("buildRemoteAwareUri", () => {
+    describe("with an existing remote workspace URI", () => {
+        const remoteUri = makeUri("vscode-remote", "ssh-remote+my-host", "/workspace/project");
+
+        it("preserves the remote scheme", () => {
+            const result = buildRemoteAwareUri("/new/path", remoteUri, fakeFileUriFactory);
+            assert.strictEqual(result.scheme, "vscode-remote");
+        });
+
+        it("preserves the remote authority", () => {
+            const result = buildRemoteAwareUri("/new/path", remoteUri, fakeFileUriFactory);
+            assert.strictEqual(result.authority, "ssh-remote+my-host");
+        });
+
+        it("uses the supplied target path", () => {
+            const result = buildRemoteAwareUri("/new/path", remoteUri, fakeFileUriFactory);
+            assert.strictEqual(result.path, "/new/path");
+        });
+
+        it("does not fall back to the fileUriFactory", () => {
+            let factoryCalled = false;
+            buildRemoteAwareUri("/new/path", remoteUri, (p) => {
+                factoryCalled = true;
+                return fakeFileUriFactory(p);
+            });
+            assert.strictEqual(factoryCalled, false);
+        });
+    });
+
+    describe("with a Devant cloud editor URI pattern", () => {
+        const devantUri = makeUri(
+            "vscode-remote",
+            "c06bfa53-8eee-40c1-b975-ea8a654dc4c1.editor.e1-us-east-azure.devant.dev",
+            "/tmp/chouser/project"
+        );
+
+        it("preserves the Devant remote authority", () => {
+            const result = buildRemoteAwareUri("/tmp/chouser/new-project", devantUri, fakeFileUriFactory);
+            assert.strictEqual(result.scheme, "vscode-remote");
+            assert.strictEqual(result.authority, "c06bfa53-8eee-40c1-b975-ea8a654dc4c1.editor.e1-us-east-azure.devant.dev");
+            assert.strictEqual(result.path, "/tmp/chouser/new-project");
+        });
+    });
+
+    describe("without an existing workspace URI (local session)", () => {
+        it("falls back to the fileUriFactory", () => {
+            let factoryArg: string | undefined;
+            buildRemoteAwareUri("/local/path", undefined, (p) => {
+                factoryArg = p;
+                return fakeFileUriFactory(p);
+            });
+            assert.strictEqual(factoryArg, "/local/path");
+        });
+
+        it("returns a file-scheme URI", () => {
+            const result = buildRemoteAwareUri("/local/path", undefined, fakeFileUriFactory);
+            assert.strictEqual(result.scheme, "file");
+        });
+
+        it("uses the supplied target path", () => {
+            const result = buildRemoteAwareUri("/local/path", undefined, fakeFileUriFactory);
+            assert.strictEqual(result.path, "/local/path");
+        });
+    });
+
+    describe("regression: plain Uri.file() would have broken the remote case", () => {
+        it("a file:// URI loses the remote authority — confirming why the fix is needed", () => {
+            const brokenLocalUri = makeUri("file", "", "/new/path");
+            assert.strictEqual(brokenLocalUri.scheme, "file");
+            assert.strictEqual(brokenLocalUri.authority, "");
+        });
+
+        it("buildRemoteAwareUri does NOT produce a file:// URI when a remote workspace exists", () => {
+            const remoteUri = makeUri("vscode-remote", "ssh-remote+host", "/original");
+            const result = buildRemoteAwareUri("/new/path", remoteUri, fakeFileUriFactory);
+            assert.notStrictEqual(result.scheme, "file");
+        });
+    });
+});

--- a/wi/wi-extension/src/utils/pathUtils.ts
+++ b/wi/wi-extension/src/utils/pathUtils.ts
@@ -21,6 +21,8 @@ import * as os from "os";
 import * as path from "path";
 import { Uri, commands, window, workspace } from "vscode";
 import { relativePath } from "../cloud/git/util";
+import { buildRemoteAwareUri } from "./uriUtils";
+import { ext } from "../extensionVariables";
 
 
 export const getNormalizedPath = (filePath: string): string => {
@@ -102,23 +104,24 @@ export async function openDirectory(openingPath: string, message: string, onSele
         onSelect();
     }
 
-    // In VS Code Remote (cloud editor), workspace folder URIs carry a remote authority
-    // (e.g. vscode-remote://ssh-remote+host/path). Preserve the scheme and authority from
-    // the existing workspace so the folder opens on the correct remote host. Fall back to
-    // Uri.file() for local-only sessions where no workspace folder exists yet.
     const existingWorkspaceUri = workspace.workspaceFolders?.[0]?.uri;
-    const buildFolderUri = (p: string) =>
-        existingWorkspaceUri ? existingWorkspaceUri.with({ path: p }) : Uri.file(p);
+    ext.log(`[openDirectory] existingWorkspaceUri: ${existingWorkspaceUri?.toString() ?? "none"}`);
+    ext.log(`[openDirectory] targetPath: ${openingPath}`);
+    const buildFolderUri = (p: string) => buildRemoteAwareUri(p, existingWorkspaceUri, (fp) => Uri.file(fp));
 
     if (openInCurrentWorkspace === "Current Window") {
         const currentFolder = workspace.workspaceFolders?.[0]?.uri.fsPath;
         if (currentFolder && isSamePath(currentFolder, openingPath)) {
             await commands.executeCommand("workbench.action.reloadWindow");
         } else {
-            await commands.executeCommand("vscode.openFolder", buildFolderUri(openingPath), { forceNewWindow: false });
+            const folderUri = buildFolderUri(openingPath);
+            ext.log(`[openDirectory] resolved folderUri (current window): ${folderUri.toString()}`);
+            await commands.executeCommand("vscode.openFolder", folderUri, { forceNewWindow: false });
         }
         await commands.executeCommand("workbench.explorer.fileView.focus");
     } else if (openInCurrentWorkspace === "New Window") {
-        await commands.executeCommand("vscode.openFolder", buildFolderUri(openingPath), { forceNewWindow: true });
+        const folderUri = buildFolderUri(openingPath);
+        ext.log(`[openDirectory] resolved folderUri (new window): ${folderUri.toString()}`);
+        await commands.executeCommand("vscode.openFolder", folderUri, { forceNewWindow: true });
     }
 }

--- a/wi/wi-extension/src/utils/pathUtils.ts
+++ b/wi/wi-extension/src/utils/pathUtils.ts
@@ -101,15 +101,24 @@ export async function openDirectory(openingPath: string, message: string, onSele
     if (openInCurrentWorkspace && onSelect) {
         onSelect();
     }
+
+    // In VS Code Remote (cloud editor), workspace folder URIs carry a remote authority
+    // (e.g. vscode-remote://ssh-remote+host/path). Preserve the scheme and authority from
+    // the existing workspace so the folder opens on the correct remote host. Fall back to
+    // Uri.file() for local-only sessions where no workspace folder exists yet.
+    const existingWorkspaceUri = workspace.workspaceFolders?.[0]?.uri;
+    const buildFolderUri = (p: string) =>
+        existingWorkspaceUri ? existingWorkspaceUri.with({ path: p }) : Uri.file(p);
+
     if (openInCurrentWorkspace === "Current Window") {
         const currentFolder = workspace.workspaceFolders?.[0]?.uri.fsPath;
         if (currentFolder && isSamePath(currentFolder, openingPath)) {
             await commands.executeCommand("workbench.action.reloadWindow");
         } else {
-            await commands.executeCommand("vscode.openFolder", Uri.file(openingPath), { forceNewWindow: false });
+            await commands.executeCommand("vscode.openFolder", buildFolderUri(openingPath), { forceNewWindow: false });
         }
         await commands.executeCommand("workbench.explorer.fileView.focus");
     } else if (openInCurrentWorkspace === "New Window") {
-        await commands.executeCommand("vscode.openFolder", Uri.file(openingPath), { forceNewWindow: true });
+        await commands.executeCommand("vscode.openFolder", buildFolderUri(openingPath), { forceNewWindow: true });
     }
 }

--- a/wi/wi-extension/src/utils/uriUtils.ts
+++ b/wi/wi-extension/src/utils/uriUtils.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// No vscode import — this file must stay free of VS Code dependencies so it can be unit-tested
+// with plain Node.js without launching the extension host.
+
+export interface UriLike {
+    readonly scheme: string;
+    readonly authority: string;
+    readonly path: string;
+    with(change: { path: string }): UriLike;
+    toString(): string;
+}
+
+/**
+ * Builds a folder URI for `vscode.openFolder`, preserving the remote scheme and authority
+ * of the existing workspace URI.
+ *
+ * In VS Code Remote / cloud editor, every workspace folder URI carries a remote authority
+ * (e.g. `vscode-remote://ssh-remote+host/project`). Constructing a plain `Uri.file(path)`
+ * drops the authority, causing VS Code to open the folder on the local client instead of
+ * the remote server — resulting in a wrong workspace root, broken webviews, and the lang
+ * server receiving unrelated files.
+ *
+ * @param targetPath     Absolute path on the remote (or local) filesystem.
+ * @param existingUri    Current workspace folder URI whose scheme/authority should be kept.
+ * @param fileUriFactory Factory for local file URIs; pass `Uri.file` from the vscode module.
+ */
+export function buildRemoteAwareUri(
+    targetPath: string,
+    existingUri: Pick<UriLike, "with"> | undefined,
+    fileUriFactory: (p: string) => UriLike
+): UriLike {
+    return existingUri ? existingUri.with({ path: targetPath }) : fileUriFactory(targetPath);
+}


### PR DESCRIPTION
## Purpose
$title
Addresses: https://github.com/wso2/product-integrator/issues/1672

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced workspace reopening to properly handle remote development environments.

* **Tests**
  * Added unit tests for remote-aware URI handling in local and remote development scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->