### PR TITLE
Fix Devant login failure

### DIFF
--- a/wi/wi-extension/package.json
+++ b/wi/wi-extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "WSO2 Integrator",
   "description": "Integration development environment for WSO2 Integrator",
   "version": "1.0.0",
-  "cliVersion": "v1.2.212605091630",
+  "cliVersion": "v1.2.212606121500",
   "publisher": "wso2",
   "icon": "resources/icons/wso2-integrator-logo.png",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Purpose

  Devant login panicked with a nil pointer dereference for affected users immediately after choosing "Login with a web browser":

  panic: runtime error: invalid memory address or nil pointer dereference
  github.com/wso2-enterprise/choreo-cli/pkg/api.(*AccessToken).IsExpired(...)
      pkg/api/models.go:103
  github.com/wso2-enterprise/choreo-cli/internal/auth.(*ReadOnlyTokenStore).getToken(...)
      internal/auth/token.go:80
  ...
  github.com/wso2-enterprise/choreo-cli/internal/auth.ClearAuthStores()
      internal/auth/auth.go:188

  ## Root cause

  `AccessToken.IsExpired()` decoded the token's JWT claims and used them without a nil check:

  ```go
  func (t *AccessToken) IsExpired() bool {
      claims := t.GetDecodedToken()   // returns nil when AccessToken isn't a decodable JWT
      ...
      expTime := time.Unix(claims.Exp, 0)...   // ← nil dereference (models.go:103)
  }
```

  GetDecodedToken() returns nil whenever the access token is not a well-formed JWT
  (not three dot-separated segments, or base64/JSON decode fails). When that happened,
  IsExpired() dereferenced the nil claims and the process crashed.

  During choreo login, the flow HandleAuthCode → ClearAuthStores() → OrgStore.GetOrgs() → GetOrganizations() → getToken() retrieves the cached token for
  the previously selected
  org. If that cached token decoded to nil claims, getToken reached the
  else if token.IsExpired() branch and panicked.

  Who was affected and why

  The crash only triggers when the keyring already contains a cached token for the prior
  default org and that token's AccessToken is not a decodable JWT.

  - Established users authenticating through the browser flow always had a valid JWT cached,
  so GetDecodedToken() returned real claims and the nil path was never reached.
  - Users coming through the new-user / PAT path ended up with a cached token that isn't a
  decodable JWT (e.g. an opaque Personal Access Token). On the next login,
  ClearAuthStores() read that token, hit the nil claims, and crashed.

  Fix

  Guard against nil claims in IsExpired() and treat an undecodable token as not expired,
  so it is used as-is rather than dereferencing nil or being forced through a refresh/exchange
  path it doesn't support (an opaque PAT has no JWT expiry to evaluate):

  claims := t.GetDecodedToken()
  if claims == nil {
      // will be unable to decode a PAT and therefore, we need to assume PAT has not expired yet
      return false
  }

  This mirrors the same guard already merged in #600 and brings this branch in line with main.

  Fix commit: https://github.com/wso2-enterprise/choreo-cli/commit/49694e6b02887ab3a904d7ec96e066c25b63dd61

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated extension CLI version to the latest stable release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->