### PR TITLE
ci: pin Windows jobs to windows-2022

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -503,7 +503,7 @@ jobs:
   build-windows:
     if: ${{ github.event.inputs.build_windows == 'true' }}
     name: Build (Windows)
-    runs-on: windows-latest
+    runs-on: windows-2022
     needs: [resolve-versions, compile]
     defaults:
       run:

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -165,7 +165,7 @@ jobs:
   windows:
     if: inputs.windows_artifact_name != '' || inputs.integrator_version != ''
     name: ${{ matrix.example }} (Windows)
-    runs-on: windows-latest
+    runs-on: windows-2022
     timeout-minutes: 25
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
- The `windows-latest` GitHub runner image rolled to Visual Studio 18, which the bundled `node-gyp@11.2.0` cannot detect (`find VS unknown version "undefined" found at "...\Microsoft Visual Studio\18\Enterprise"`). Native-module installs in the Windows build job fail as a result.
- Pin both Windows jobs (`build-windows` in `build-and-release.yml` and the `windows` smoke-test matrix in `smoke-test.yml`) to `windows-2022` to restore green builds until node-gyp ships VS 18 support.

Reference failing run: https://github.com/wso2/product-integrator/actions/runs/27492680926/job/81263148051

## Test plan
- [ ] Re-trigger the `Build and Release Artifacts` workflow on `5.0.x` and confirm `Build (Windows)` succeeds.
- [ ] Confirm Windows smoke-test matrix runs to completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and test infrastructure configurations to use consistent runner environments for improved reliability and stability across CI/CD pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->