### PR TITLE
Update wso2ipw for ICP smoke test

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -125,7 +125,7 @@ jobs:
           node-version: '20'
 
       - name: Install wso2ipw
-        run: npm install -g https://github.com/manuranga/wso2ipw/archive/refs/tags/v0.1.10.tar.gz
+        run: npm install -g wso2ipw@0.1.10
 
       - name: Install playwright-cli and Chrome
         if: matrix.example == 'icp'
@@ -224,7 +224,7 @@ jobs:
           node-version: '20'
 
       - name: Install wso2ipw
-        run: npm install -g https://github.com/manuranga/wso2ipw/archive/refs/tags/v0.1.10.tar.gz
+        run: npm install -g wso2ipw@0.1.10
 
       - name: Install playwright-cli and Chrome
         if: matrix.example == 'icp'

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -125,7 +125,7 @@ jobs:
           node-version: '20'
 
       - name: Install wso2ipw
-        run: npm install -g wso2ipw@0.1.8
+        run: npm install -g https://github.com/manuranga/wso2ipw/archive/refs/tags/v0.1.10.tar.gz
 
       - name: Install playwright-cli and Chrome
         if: matrix.example == 'icp'
@@ -224,7 +224,7 @@ jobs:
           node-version: '20'
 
       - name: Install wso2ipw
-        run: npm install -g wso2ipw@0.1.8
+        run: npm install -g https://github.com/manuranga/wso2ipw/archive/refs/tags/v0.1.10.tar.gz
 
       - name: Install playwright-cli and Chrome
         if: matrix.example == 'icp'


### PR DESCRIPTION
Updates the smoke-test workflow to use the fixed wso2ipw tag for ICP navigation.\n\nThe failed 5.0.x run timed out on a stale guest selector:\n\n    getByRole('button', { name: /HelloWorld/ })\n\nIn the current 5.0.x UI the resource breadcrumb uses Artifacts > HTTP Service > resource, so no guest button named HelloWorld exists. wso2ipw v0.1.10 navigates back via the host Open Overview action, which was verified locally in a Lima amd64 Ubuntu VM to get past the original timeout and reach the ICP monitoring checkbox.\n\nNote: npm publishing of v0.1.10 is currently blocked by npm token permissions in manuranga/wso2ipw, so this PR pins the immutable GitHub tag tarball for validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Linux and Windows smoke-test workflows to install the `wso2ipw` tool from the GitHub release tarball for tag `v0.1.10` (instead of the previously pinned npm version).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->