### PR TITLE
Add `keep-structure` setting to migration wizard

### DIFF
--- a/wi/wi-core/src/types/webview-api.types.ts
+++ b/wi/wi-core/src/types/webview-api.types.ts
@@ -227,6 +227,7 @@ export interface MigrateRequest {
     projects?: ProjectMigrationResult[];
     aiFeatureUsed?: boolean;
     sourcePath?: string;
+    keepStructure?: boolean;
 }
 
 export interface PullMigrationToolRequest {

--- a/wi/wi-extension/src/bi/ballerinaContext.ts
+++ b/wi/wi-extension/src/bi/ballerinaContext.ts
@@ -22,7 +22,7 @@ import { EXTENSION_DEPENDENCIES, DownloadProgress, WIChatNotify } from "@wso2/wi
 
 /** Shape of the migration API exposed by the Ballerina extension's `activate()` return value. */
 export interface BallerinaExtMigrationAPI {
-    setWizardProjectRoot: (projectRoot: string, sourcePath?: string) => void;
+    setWizardProjectRoot: (projectRoot: string, sourcePath?: string, keepStructure?: boolean) => void;
     wizardEnhancementReady: () => Promise<void>;
     abortAgent: () => void;
     openMigratedProject: () => void;

--- a/wi/wi-extension/src/ws-managers/main/ws-manager.ts
+++ b/wi/wi-extension/src/ws-managers/main/ws-manager.ts
@@ -554,7 +554,7 @@ export class MainWsManager implements WIVisualizerAPI {
                     const projectRoot = typeof result === "string" ? result : undefined;
                     if (projectRoot) {
                         const migrationAPI = await ballerinaContext.ensureMigrationAPI();
-                        migrationAPI?.setWizardProjectRoot(projectRoot, params.sourcePath);
+                        migrationAPI?.setWizardProjectRoot(projectRoot, params.sourcePath, params.keepStructure);
                         // Ensure the BridgeLayer forwards chat events now that the API is available
                         BridgeLayer.setupMigrationSubscription(this.projectUri ?? "global");
                     }

--- a/wi/wi-webviews/src/views/ImportIntegration/ConfigureProjectForm.tsx
+++ b/wi/wi-webviews/src/views/ImportIntegration/ConfigureProjectForm.tsx
@@ -305,7 +305,7 @@ export function ConfigureProjectForm({ isMultiProject, onNext, onBack, selectedO
             isExpanded={isOptionsExpanded}
             onToggle={() => setIsOptionsExpanded(v => !v)}
             icon="gear"
-            title="Output Options"
+            title="Output Structure"
         >
             <CheckBox
                 label="Keep Original Structure"

--- a/wi/wi-webviews/src/views/ImportIntegration/ConfigureProjectForm.tsx
+++ b/wi/wi-webviews/src/views/ImportIntegration/ConfigureProjectForm.tsx
@@ -16,7 +16,9 @@
  * under the License.
  */
 
-import { ActionButtons, Typography } from "@wso2/ui-toolkit";
+import { ActionButtons, CheckBox, Typography } from "@wso2/ui-toolkit";
+import styled from "@emotion/styled";
+import { CollapsibleSection } from "../creationView/biForm/components/CollapsibleSection";
 import { useEffect, useState } from "react";
 import { useVisualizerContext } from "../../contexts";
 import { ValidateProjectFormErrorField } from "@wso2/wi-core";
@@ -27,7 +29,13 @@ import { MultiProjectFormData, MultiProjectFormFields } from "./components/Multi
 import { ButtonWrapper } from "./styles";
 import { ConfigureProjectFormProps } from "./types";
 
-export function ConfigureProjectForm({ isMultiProject, onNext, onBack, selectedOrgName }: ConfigureProjectFormProps) {
+const OptionDescription = styled.div`
+    color: var(--vscode-list-deemphasizedForeground);
+    margin-top: 4px;
+    margin-left: 26px;
+`;
+
+export function ConfigureProjectForm({ isMultiProject, onNext, onBack, selectedOrgName, keepStructure, onKeepStructureChange, selectedIntegration }: ConfigureProjectFormProps) {
     const { wsClient } = useVisualizerContext();
     const [singleIntegrationData, setSingleIntegrationData] = useState<ProjectFormData>({
         integrationName: "",
@@ -50,6 +58,7 @@ export function ConfigureProjectForm({ isMultiProject, onNext, onBack, selectedO
     });
 
     const [isValidating, setIsValidating] = useState(false);
+    const [isOptionsExpanded, setIsOptionsExpanded] = useState(false);
     const [pathError, setPathError] = useState<string | null>(null);
     const [folderNameError, setFolderNameError] = useState<string | null>(null);
     const [singleIntegrationNameError, setSingleIntegrationNameError] = useState<string | null>(null);
@@ -287,6 +296,26 @@ export function ConfigureProjectForm({ isMultiProject, onNext, onBack, selectedO
         }
     };
 
+    const keepStructureDesc = selectedIntegration?.commandName === "migrate-tibco"
+        ? "Preserve the original source file structure (each process in a separate .bal file)."
+        : "Preserve the original source file structure (each .xml in a separate .bal file).";
+
+    const outputOptionsCollapsible = (
+        <CollapsibleSection
+            isExpanded={isOptionsExpanded}
+            onToggle={() => setIsOptionsExpanded(v => !v)}
+            icon="gear"
+            title="Output Options"
+        >
+            <CheckBox
+                label="Keep Original Structure"
+                checked={keepStructure}
+                onChange={onKeepStructureChange}
+            />
+            <OptionDescription>{keepStructureDesc}</OptionDescription>
+        </CollapsibleSection>
+    );
+
     return (
         <>
             {isMultiProject ? (
@@ -299,6 +328,8 @@ export function ConfigureProjectForm({ isMultiProject, onNext, onBack, selectedO
                         pathError={pathError || undefined}
                         folderNameError={folderNameError || undefined}
                     />
+
+                    {outputOptionsCollapsible}
 
                     <ButtonWrapper>
                         <ActionButtons
@@ -333,6 +364,8 @@ export function ConfigureProjectForm({ isMultiProject, onNext, onBack, selectedO
                         onCloudProjectNameError={setSingleIntegrationCloudProjectNameError}
                         onCloudProjectHandleError={setSingleIntegrationCloudProjectHandleError}
                     />
+
+                    {outputOptionsCollapsible}
 
                     <ButtonWrapper>
                         <ActionButtons

--- a/wi/wi-webviews/src/views/ImportIntegration/ImportIntegrationForm.tsx
+++ b/wi/wi-webviews/src/views/ImportIntegration/ImportIntegrationForm.tsx
@@ -72,7 +72,7 @@ export function ImportIntegrationForm({
 
     const isImportDisabled = importSourcePath.length < 2 || !selectedIntegration;
 
-    const boolParam = selectedIntegration?.parameters.find(p => p.valueType === "boolean") ?? null;
+    const boolParam = selectedIntegration?.parameters.find(p => p.key === "multiRoot") ?? null;
     const getBoolValue = (key: string): boolean => {
         const v = integrationParams[key];
         return typeof v === "string" ? v === "true" : v === true;

--- a/wi/wi-webviews/src/views/ImportIntegration/components/IntegrationParameters.tsx
+++ b/wi/wi-webviews/src/views/ImportIntegration/components/IntegrationParameters.tsx
@@ -48,7 +48,7 @@ export const IntegrationParameters: React.FC<IntegrationParametersProps> = ({
     onParameterChange,
 }) => {
     const [isExpanded, setIsExpanded] = useState(false);
-    const collapsibleParams = (selectedIntegration?.parameters.filter(p => p.key !== "multiRoot") ?? [])
+    const collapsibleParams = (selectedIntegration?.parameters.filter(p => p.key !== "multiRoot" && p.key !== "keepStructure") ?? [])
         .sort((a, b) => (a.valueType === "boolean" ? -1 : b.valueType === "boolean" ? 1 : 0));
     if (!selectedIntegration || !collapsibleParams.length) return null;
 

--- a/wi/wi-webviews/src/views/ImportIntegration/components/IntegrationParameters.tsx
+++ b/wi/wi-webviews/src/views/ImportIntegration/components/IntegrationParameters.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { Dropdown, OptionProps, TextField } from "@wso2/ui-toolkit";
+import { CheckBox, Dropdown, OptionProps, TextField } from "@wso2/ui-toolkit";
 import React, { useState } from "react";
 import { BodyText, ParameterItem, ParametersSection } from "../styles";
 import { CollapsibleSection } from "../../../views/creationView/biForm/components/CollapsibleSection";
@@ -28,6 +28,12 @@ const ParametersContainer = styled.div`
     flex-direction: column;
     gap: 16px;
     margin-top: 16px;
+`;
+
+const ParamDescription = styled.div`
+    color: var(--vscode-list-deemphasizedForeground);
+    margin-top: 4px;
+    margin-left: 26px;
 `;
 
 interface IntegrationParametersProps {
@@ -42,8 +48,9 @@ export const IntegrationParameters: React.FC<IntegrationParametersProps> = ({
     onParameterChange,
 }) => {
     const [isExpanded, setIsExpanded] = useState(false);
-    const nonBoolParams = selectedIntegration?.parameters.filter(p => p.valueType !== "boolean") ?? [];
-    if (!selectedIntegration || !nonBoolParams.length) return null;
+    const collapsibleParams = (selectedIntegration?.parameters.filter(p => p.key !== "multiRoot") ?? [])
+        .sort((a, b) => (a.valueType === "boolean" ? -1 : b.valueType === "boolean" ? 1 : 0));
+    if (!selectedIntegration || !collapsibleParams.length) return null;
 
     return (
         <ParametersSection>
@@ -51,13 +58,24 @@ export const IntegrationParameters: React.FC<IntegrationParametersProps> = ({
                 isExpanded={isExpanded}
                 onToggle={() => setIsExpanded(v => !v)}
                 icon="gear"
-                title={`Configure ${selectedIntegration.title} Settings`}
+                title="Configure Additional Settings"
             >
-                <BodyText>{`Configure additional settings for ${selectedIntegration.title} migration.`}</BodyText>
+                <BodyText>Configure additional settings for your migration.</BodyText>
                 <ParametersContainer>
-                    {nonBoolParams.map((param) => (
+                    {collapsibleParams.map((param) => (
                         <ParameterItem key={param.key}>
-                            {param.valueType === "enum" && param.options ? (
+                            {param.valueType === "boolean" ? (
+                                <>
+                                    <CheckBox
+                                        label={param.label}
+                                        checked={integrationParams[param.key] === true || integrationParams[param.key] === "true"}
+                                        onChange={(checked) => onParameterChange(param.key, checked)}
+                                    />
+                                    {param.description && (
+                                        <ParamDescription>{param.description}</ParamDescription>
+                                    )}
+                                </>
+                            ) : param.valueType === "enum" && param.options ? (
                                 <Dropdown
                                     id={`${param.key}-dropdown`}
                                     label={param.label}

--- a/wi/wi-webviews/src/views/ImportIntegration/components/IntegrationParameters.tsx
+++ b/wi/wi-webviews/src/views/ImportIntegration/components/IntegrationParameters.tsx
@@ -49,7 +49,7 @@ export const IntegrationParameters: React.FC<IntegrationParametersProps> = ({
 }) => {
     const [isExpanded, setIsExpanded] = useState(false);
     const collapsibleParams = (selectedIntegration?.parameters.filter(p => p.key !== "multiRoot" && p.key !== "keepStructure") ?? [])
-        .sort((a, b) => (a.valueType === "boolean" ? -1 : b.valueType === "boolean" ? 1 : 0));
+        .sort((a, b) => (b.valueType === "boolean" ? 1 : 0) - (a.valueType === "boolean" ? 1 : 0));
     if (!selectedIntegration || !collapsibleParams.length) return null;
 
     return (

--- a/wi/wi-webviews/src/views/ImportIntegration/index.tsx
+++ b/wi/wi-webviews/src/views/ImportIntegration/index.tsx
@@ -80,7 +80,7 @@ export function ImportIntegration({ onBack }: { onBack?: () => void }) {
     const defaultSteps = ["Configure Source", "Report Generation", "Configure Destination", "Rule-Based Migration", "AI Enhancement"];
 
     // isMultiProject for ConfigureProjectForm is derived from the source config (step 0 selection)
-    const boolParamKey = selectedIntegration?.parameters.find(p => p.valueType === "boolean")?.key;
+    const boolParamKey = selectedIntegration?.parameters.find(p => p.key === "multiRoot")?.key;
     const isMultiProjectFromConfig = boolParamKey ? importParams?.parameters?.[boolParamKey] === true : false;
     // isMultiProject for MigrationProgressView is derived from actual dry-run results
     const isMultiProject = migratedProjects.length > 0;

--- a/wi/wi-webviews/src/views/ImportIntegration/index.tsx
+++ b/wi/wi-webviews/src/views/ImportIntegration/index.tsx
@@ -234,6 +234,7 @@ export function ImportIntegration({ onBack }: { onBack?: () => void }) {
             projects: migratedProjects,
             aiFeatureUsed: true,
             sourcePath: importParams.importSourcePath,
+            keepStructure,
         });
         onBack?.();
     };

--- a/wi/wi-webviews/src/views/ImportIntegration/index.tsx
+++ b/wi/wi-webviews/src/views/ImportIntegration/index.tsx
@@ -207,6 +207,7 @@ export function ImportIntegration({ onBack }: { onBack?: () => void }) {
             projects: migratedProjects,
             aiFeatureUsed: true,
             sourcePath: importParams.importSourcePath,
+            keepStructure,
         });
         setAiEnhancementActive(true);
         setStep(4);

--- a/wi/wi-webviews/src/views/ImportIntegration/index.tsx
+++ b/wi/wi-webviews/src/views/ImportIntegration/index.tsx
@@ -63,6 +63,7 @@ export function ImportIntegration({ onBack }: { onBack?: () => void }) {
     const [migrationSuccessful, setMigrationSuccessful] = useState(false);
     const [migrationResponse, setMigrationResponse] = useState<ImportIntegrationResponse | null>(null);
     const [aiEnhancementActive, setAiEnhancementActive] = useState(false);
+    const [keepStructure, setKeepStructure] = useState(false);
     const [storedProjectRequest, setStoredProjectRequest] = useState<ProjectRequest | null>(null);
     const migrationStartedRef = useRef(false);
 
@@ -84,6 +85,11 @@ export function ImportIntegration({ onBack }: { onBack?: () => void }) {
     const isMultiProjectFromConfig = boolParamKey ? importParams?.parameters?.[boolParamKey] === true : false;
     // isMultiProject for MigrationProgressView is derived from actual dry-run results
     const isMultiProject = migratedProjects.length > 0;
+
+    const handleSelectIntegration = (integration: typeof selectedIntegration) => {
+        setSelectedIntegration(integration);
+        setKeepStructure(false);
+    };
 
     const pullIntegrationTool = (commandName: string) => {
         setPullingTool(true);
@@ -135,7 +141,7 @@ export function ImportIntegration({ onBack }: { onBack?: () => void }) {
             commandName: integration.commandName,
             sourcePath: params.importSourcePath,
             orgName: selectedOrgName,
-            parameters: params.parameters,
+            parameters: { ...params.parameters, keepStructure },
         };
         try {
             const response = await wsClient.importIntegration(wsParams);
@@ -359,7 +365,7 @@ export function ImportIntegration({ onBack }: { onBack?: () => void }) {
                                 pullIntegrationTool={pullIntegrationTool}
                                 pullingTool={pullingTool}
                                 toolPullProgress={toolPullProgress}
-                                onSelectIntegration={setSelectedIntegration}
+                                onSelectIntegration={handleSelectIntegration}
                                 onNext={() => setStep(1)}
                                 onBack={onBack}
                             />
@@ -387,6 +393,9 @@ export function ImportIntegration({ onBack }: { onBack?: () => void }) {
                                 onNext={handleConfigureDestinationDone}
                                 onBack={handleStepBack}
                                 selectedOrgName={selectedOrgName}
+                                keepStructure={keepStructure}
+                                onKeepStructureChange={setKeepStructure}
+                                selectedIntegration={selectedIntegration}
                             />
                         )}
                         {step === 3 && (

--- a/wi/wi-webviews/src/views/ImportIntegration/types.ts
+++ b/wi/wi-webviews/src/views/ImportIntegration/types.ts
@@ -106,6 +106,9 @@ export interface ConfigureProjectFormProps {
     onNext: (project: ProjectRequest, aiFeatureUsed: boolean) => Promise<void> | void;
     onBack: () => void;
     selectedOrgName?: string;
+    keepStructure: boolean;
+    onKeepStructureChange: (value: boolean) => void;
+    selectedIntegration?: MigrationTool | null;
 }
 
 export interface MigrationDisplayState {

--- a/wi/wi-webviews/src/views/creationView/biForm/components/AdvancedConfigurationSection.tsx
+++ b/wi/wi-webviews/src/views/creationView/biForm/components/AdvancedConfigurationSection.tsx
@@ -325,7 +325,7 @@ export function AdvancedConfigurationSection({
             isExpanded={isExpanded}
             onToggle={onToggle}
             icon="gear"
-            title="Package Settings"
+            title="Advanced Configurations"
             hasError={hasError}
         >
             {createWithinProject && (

--- a/wi/wi-webviews/src/views/creationView/biForm/components/AdvancedConfigurationSection.tsx
+++ b/wi/wi-webviews/src/views/creationView/biForm/components/AdvancedConfigurationSection.tsx
@@ -325,7 +325,7 @@ export function AdvancedConfigurationSection({
             isExpanded={isExpanded}
             onToggle={onToggle}
             icon="gear"
-            title="Advanced Configurations"
+            title="Package Settings"
             hasError={hasError}
         >
             {createWithinProject && (


### PR DESCRIPTION
## Purpose
$subject.

Fixes #1642

## Preview
- Multi Project
<img width="1089" height="531" alt="Screenshot 2026-06-26 at 11 33 00" src="https://github.com/user-attachments/assets/45e4b508-bde2-4fc6-9550-ff81516c2db3" />

- Single Project
<img width="1080" height="668" alt="Screenshot 2026-06-26 at 11 31 25" src="https://github.com/user-attachments/assets/c96db351-eaec-44cd-9d10-8911aec9304d" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a collapsible **Output Structure** option to the import/migration setup to let you keep (or not keep) the project structure.
  * Enhanced **Additional Settings** to render boolean migration parameters as checkboxes and streamline the additional-settings section content.

* **Bug Fixes**
  * Fixed **Single Project / Multiple Projects** selection to use the correct **multiRoot** setting.
  * Ensured your **Output Structure** preference is included in both standard and AI-assisted migration flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->