### PR TITLE
Fix patches to unblock the pipeline

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -220,11 +220,28 @@ jobs:
           restore-keys: |
             sysroots-${{ runner.os }}-
 
+      # The runner image ships a pinned apt index. Once the archive supersedes a
+      # package (e.g. a krb5 security update), the old .deb is dropped from the pool
+      # and the stale index resolves to a 404. cache-apt-pkgs-action does not refresh
+      # the index itself, so do it here.
+      - name: Refresh apt package index
+        run: sudo apt-get update
+
       - name: Cache apt packages
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: build-essential g++ libx11-dev libxkbfile-dev libsecret-1-dev libkrb5-dev python-is-python3 quilt
-          version: 1.0
+          # Bumped from 1.0 to invalidate caches poisoned by the 404 above: when the
+          # fetch failed, the action still saved an empty (2 KB) cache under the old
+          # key, so every later run got a cache hit that installed nothing and failed
+          # downstream with "quilt: command not found".
+          version: 1.1
+
+      - name: Verify apt packages installed
+        run: |
+          for c in quilt g++; do
+            command -v "$c" >/dev/null || { echo "::error::$c missing after apt install step"; exit 1; }
+          done
 
       - name: Install Rust toolchain
         run: |

--- a/installers/linux-rpm/wso2-integrator.spec
+++ b/installers/linux-rpm/wso2-integrator.spec
@@ -14,6 +14,13 @@ that brings together Ballerina language runtime, WSO2 Integration Control Plane,
 and low-code editor in one unified package.
 
 %global debug_package %{nil}
+# Disable RPM's automatic post-install processing (binary strip, etc.). This is a
+# bundled Electron app: resources/app/node_modules/@microsoft/mxc-sdk ships prebuilt
+# cross-platform binaries (e.g. bin/arm64/*), and the x86_64 build host's `strip`
+# cannot parse the ARM64 ELF files, which aborts the %install phase. Electron/Node
+# binaries must not be stripped anyway, so skip the whole brp step (matches deb, which
+# does not auto-strip).
+%global __os_install_post %{nil}
 %prep
 %setup -q -c
 

--- a/patches/coreCiSerializeBundles.diff
+++ b/patches/coreCiSerializeBundles.diff
@@ -1,0 +1,16 @@
+Index: product-integrator/lib/vscode/build/gulpfile.vscode.ts
+===================================================================
+--- product-integrator.orig/lib/vscode/build/gulpfile.vscode.ts
++++ product-integrator/lib/vscode/build/gulpfile.vscode.ts
+@@ -193,7 +193,10 @@ task.task(task.define('core-ci', task.series(
+ 	// Transpile individual files to out-build first (for unit tests)
+ 	task.define('esbuild-out-build', () => runEsbuildTranspile('out-build', false)),
+ 	// Then bundle for shipping (bundles also write NLS files to out-build)
+-	task.parallel(
++	// WSO2: serialized (was task.parallel) so only one esbuild minify bundle runs at a
++	// time. Running all three in parallel alongside the 8 GB gulp heap OOM-kills the
++	// esbuild service on the memory-limited CodeBuild runner during minify.
++	task.series(
+ 		task.define('esbuild-vscode-min', () => runEsbuildBundle('out-vscode-min', true, true, 'desktop', `${sourceMappingURLBase}/core`)),
+ 		task.define('esbuild-vscode-reh-min', () => runEsbuildBundle('out-vscode-reh-min', true, true, 'server', `${sourceMappingURLBase}/core`)),
+ 		task.define('esbuild-vscode-reh-web-min', () => runEsbuildBundle('out-vscode-reh-web-min', true, true, 'server-web', `${sourceMappingURLBase}/core`)),

--- a/patches/gettingStarted.diff
+++ b/patches/gettingStarted.diff
@@ -247,7 +247,7 @@ Index: product-integrator/lib/vscode/src/vs/workbench/browser/parts/editor/wso2E
 ===================================================================
 --- /dev/null
 +++ product-integrator/lib/vscode/src/vs/workbench/browser/parts/editor/wso2EditorGroupWatermark.ts
-@@ -0,0 +1,708 @@
+@@ -0,0 +1,667 @@
 +/*---------------------------------------------------------------------------------------------
 + *  Copyright (c) Microsoft Corporation. All rights reserved.
 + *  Licensed under the MIT License. See License.txt in the project root for license information.
@@ -256,7 +256,6 @@ Index: product-integrator/lib/vscode/src/vs/workbench/browser/parts/editor/wso2E
 +import { $, append, clearNode, getWindow } from '../../../../base/browser/dom.js';
 +import { Disposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
 +import { joinPath } from '../../../../base/common/resources.js';
-+import { IFileService } from '../../../../platform/files/common/files.js';
 +import { IWorkspaceContextService, WorkbenchState } from '../../../../platform/workspace/common/workspace.js';
 +import { ICommandService } from '../../../../platform/commands/common/commands.js';
 +import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
@@ -276,11 +275,6 @@ Index: product-integrator/lib/vscode/src/vs/workbench/browser/parts/editor/wso2E
 +	mode: 'proxy' | 'websocket';
 +	wsServer: string;
 +	wsPort: number;
-+}
-+
-+interface IBiFormRemoteState {
-+	status: 'ok' | 'missing' | 'outdated';
-+	version?: string;
 +}
 +
 +interface IEmbeddedWelcomeThemeData {
@@ -372,7 +366,6 @@ Index: product-integrator/lib/vscode/src/vs/workbench/browser/parts/editor/wso2E
 +		@IConfigurationService private readonly configurationService: IConfigurationService,
 +		@IEditorGroupsService private readonly editorGroupsService: IEditorGroupsService,
 +		@IExtensionService private readonly extensionService: IExtensionService,
-+		@IFileService private readonly fileService: IFileService,
 +		@IWebviewService private readonly webviewService: IWebviewService
 +	) {
 +		super();
@@ -553,28 +546,6 @@ Index: product-integrator/lib/vscode/src/vs/workbench/browser/parts/editor/wso2E
 +
 +		const resourcesRoot = joinPath(extension.extensionLocation, 'resources');
 +		const scriptUri = asWebviewUri(joinPath(resourcesRoot, 'jslibs', 'main.js')).toString(true);
-+		const ballerinaExtension = await this.extensionService.getExtension('wso2.ballerina');
-+		const ballerinaFederationRoot = ballerinaExtension
-+			? joinPath(ballerinaExtension.extensionLocation, 'resources', 'jslibs', 'federation')
-+			: undefined;
-+		const ballerinaRemoteEntry = ballerinaFederationRoot
-+			? joinPath(ballerinaFederationRoot, 'remoteEntry.js')
-+			: undefined;
-+		const hasBallerinaRemote = ballerinaRemoteEntry
-+			? await this.fileService.exists(ballerinaRemoteEntry)
-+			: false;
-+		const biFormRemoteState: IBiFormRemoteState = !ballerinaExtension
-+			? { status: 'missing' }
-+			: hasBallerinaRemote
-+				? { status: 'ok', version: ballerinaExtension.version }
-+				: { status: 'outdated', version: ballerinaExtension.version };
-+		const biFormRemoteUri = hasBallerinaRemote && ballerinaRemoteEntry
-+			? asWebviewUri(ballerinaRemoteEntry).toString(true)
-+			: undefined;
-+
-+		if (!this.isCurrentRenderRequest(requestId)) {
-+			return;
-+		}
 +		const themeData = this.getEmbeddedWelcomeThemeData();
 +		const webview = this.webviewService.createWebviewElement({
 +			providedViewType: WI_EMBEDDED_WELCOME_VIEW_TYPE,
@@ -582,9 +553,7 @@ Index: product-integrator/lib/vscode/src/vs/workbench/browser/parts/editor/wso2E
 +			options: {},
 +			contentOptions: {
 +				allowScripts: true,
-+				localResourceRoots: ballerinaFederationRoot && hasBallerinaRemote
-+					? [resourcesRoot, ballerinaFederationRoot]
-+					: [resourcesRoot]
++				localResourceRoots: [resourcesRoot]
 +			},
 +			extension: {
 +				id: extension.identifier,
@@ -599,7 +568,7 @@ Index: product-integrator/lib/vscode/src/vs/workbench/browser/parts/editor/wso2E
 +
 +		this.embeddedWebview.value = webview;
 +		webview.mountTo(host, getWindow(host));
-+		webview.setHtml(this.getEmbeddedWelcomeHtml(scriptUri, bootstrap, themeData, biFormRemoteUri, biFormRemoteState));
++		webview.setHtml(this.getEmbeddedWelcomeHtml(scriptUri, bootstrap, themeData));
 +	}
 +
 +	private showLoginDialogIfNeeded(): void {
@@ -639,17 +608,9 @@ Index: product-integrator/lib/vscode/src/vs/workbench/browser/parts/editor/wso2E
 +		WSO2EditorGroupWatermark.activeLoginDialogPromise = loginDialogPromise;
 +	}
 +
-+	private getEmbeddedWelcomeHtml(
-+		scriptUri: string,
-+		bootstrap: IEmbeddedWelcomeBootstrap,
-+		themeData: IEmbeddedWelcomeThemeData,
-+		biFormRemoteUri: string | undefined,
-+		biFormRemoteState: IBiFormRemoteState
-+	): string {
++	private getEmbeddedWelcomeHtml(scriptUri: string, bootstrap: IEmbeddedWelcomeBootstrap, themeData: IEmbeddedWelcomeThemeData): string {
 +		const serializedBootstrap = JSON.stringify(bootstrap).replace(/</g, '\\u003c');
 +		const serializedThemeData = JSON.stringify(themeData).replace(/</g, '\\u003c');
-+		const serializedBiFormRemote = JSON.stringify(biFormRemoteUri ?? null).replace(/</g, '\\u003c');
-+		const serializedBiFormRemoteState = JSON.stringify(biFormRemoteState).replace(/</g, '\\u003c');
 +
 +		return `<!DOCTYPE html>
 +				<html lang="en">
@@ -818,8 +779,6 @@ Index: product-integrator/lib/vscode/src/vs/workbench/browser/parts/editor/wso2E
 +					<div id="root"></div>
 +					<script>
 +						window.__WI_BRIDGE_BOOTSTRAP = ${serializedBootstrap};
-+						window.__WI_BI_FORM_REMOTE = ${serializedBiFormRemote};
-+						window.__WI_BI_FORM_REMOTE_STATE = ${serializedBiFormRemoteState};
 +						window.__WI_EMBEDDED_WELCOME_HIDE_LOADER = function () {
 +							document.body.classList.add('embedded-welcome-ready');
 +						};

--- a/patches/gettingStarted.diff
+++ b/patches/gettingStarted.diff
@@ -247,7 +247,7 @@ Index: product-integrator/lib/vscode/src/vs/workbench/browser/parts/editor/wso2E
 ===================================================================
 --- /dev/null
 +++ product-integrator/lib/vscode/src/vs/workbench/browser/parts/editor/wso2EditorGroupWatermark.ts
-@@ -0,0 +1,667 @@
+@@ -0,0 +1,708 @@
 +/*---------------------------------------------------------------------------------------------
 + *  Copyright (c) Microsoft Corporation. All rights reserved.
 + *  Licensed under the MIT License. See License.txt in the project root for license information.
@@ -256,6 +256,7 @@ Index: product-integrator/lib/vscode/src/vs/workbench/browser/parts/editor/wso2E
 +import { $, append, clearNode, getWindow } from '../../../../base/browser/dom.js';
 +import { Disposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
 +import { joinPath } from '../../../../base/common/resources.js';
++import { IFileService } from '../../../../platform/files/common/files.js';
 +import { IWorkspaceContextService, WorkbenchState } from '../../../../platform/workspace/common/workspace.js';
 +import { ICommandService } from '../../../../platform/commands/common/commands.js';
 +import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
@@ -275,6 +276,11 @@ Index: product-integrator/lib/vscode/src/vs/workbench/browser/parts/editor/wso2E
 +	mode: 'proxy' | 'websocket';
 +	wsServer: string;
 +	wsPort: number;
++}
++
++interface IBiFormRemoteState {
++	status: 'ok' | 'missing' | 'outdated';
++	version?: string;
 +}
 +
 +interface IEmbeddedWelcomeThemeData {
@@ -366,6 +372,7 @@ Index: product-integrator/lib/vscode/src/vs/workbench/browser/parts/editor/wso2E
 +		@IConfigurationService private readonly configurationService: IConfigurationService,
 +		@IEditorGroupsService private readonly editorGroupsService: IEditorGroupsService,
 +		@IExtensionService private readonly extensionService: IExtensionService,
++		@IFileService private readonly fileService: IFileService,
 +		@IWebviewService private readonly webviewService: IWebviewService
 +	) {
 +		super();
@@ -546,6 +553,28 @@ Index: product-integrator/lib/vscode/src/vs/workbench/browser/parts/editor/wso2E
 +
 +		const resourcesRoot = joinPath(extension.extensionLocation, 'resources');
 +		const scriptUri = asWebviewUri(joinPath(resourcesRoot, 'jslibs', 'main.js')).toString(true);
++		const ballerinaExtension = await this.extensionService.getExtension('wso2.ballerina');
++		const ballerinaFederationRoot = ballerinaExtension
++			? joinPath(ballerinaExtension.extensionLocation, 'resources', 'jslibs', 'federation')
++			: undefined;
++		const ballerinaRemoteEntry = ballerinaFederationRoot
++			? joinPath(ballerinaFederationRoot, 'remoteEntry.js')
++			: undefined;
++		const hasBallerinaRemote = ballerinaRemoteEntry
++			? await this.fileService.exists(ballerinaRemoteEntry)
++			: false;
++		const biFormRemoteState: IBiFormRemoteState = !ballerinaExtension
++			? { status: 'missing' }
++			: hasBallerinaRemote
++				? { status: 'ok', version: ballerinaExtension.version }
++				: { status: 'outdated', version: ballerinaExtension.version };
++		const biFormRemoteUri = hasBallerinaRemote && ballerinaRemoteEntry
++			? asWebviewUri(ballerinaRemoteEntry).toString(true)
++			: undefined;
++
++		if (!this.isCurrentRenderRequest(requestId)) {
++			return;
++		}
 +		const themeData = this.getEmbeddedWelcomeThemeData();
 +		const webview = this.webviewService.createWebviewElement({
 +			providedViewType: WI_EMBEDDED_WELCOME_VIEW_TYPE,
@@ -553,7 +582,9 @@ Index: product-integrator/lib/vscode/src/vs/workbench/browser/parts/editor/wso2E
 +			options: {},
 +			contentOptions: {
 +				allowScripts: true,
-+				localResourceRoots: [resourcesRoot]
++				localResourceRoots: ballerinaFederationRoot && hasBallerinaRemote
++					? [resourcesRoot, ballerinaFederationRoot]
++					: [resourcesRoot]
 +			},
 +			extension: {
 +				id: extension.identifier,
@@ -568,7 +599,7 @@ Index: product-integrator/lib/vscode/src/vs/workbench/browser/parts/editor/wso2E
 +
 +		this.embeddedWebview.value = webview;
 +		webview.mountTo(host, getWindow(host));
-+		webview.setHtml(this.getEmbeddedWelcomeHtml(scriptUri, bootstrap, themeData));
++		webview.setHtml(this.getEmbeddedWelcomeHtml(scriptUri, bootstrap, themeData, biFormRemoteUri, biFormRemoteState));
 +	}
 +
 +	private showLoginDialogIfNeeded(): void {
@@ -608,9 +639,17 @@ Index: product-integrator/lib/vscode/src/vs/workbench/browser/parts/editor/wso2E
 +		WSO2EditorGroupWatermark.activeLoginDialogPromise = loginDialogPromise;
 +	}
 +
-+	private getEmbeddedWelcomeHtml(scriptUri: string, bootstrap: IEmbeddedWelcomeBootstrap, themeData: IEmbeddedWelcomeThemeData): string {
++	private getEmbeddedWelcomeHtml(
++		scriptUri: string,
++		bootstrap: IEmbeddedWelcomeBootstrap,
++		themeData: IEmbeddedWelcomeThemeData,
++		biFormRemoteUri: string | undefined,
++		biFormRemoteState: IBiFormRemoteState
++	): string {
 +		const serializedBootstrap = JSON.stringify(bootstrap).replace(/</g, '\\u003c');
 +		const serializedThemeData = JSON.stringify(themeData).replace(/</g, '\\u003c');
++		const serializedBiFormRemote = JSON.stringify(biFormRemoteUri ?? null).replace(/</g, '\\u003c');
++		const serializedBiFormRemoteState = JSON.stringify(biFormRemoteState).replace(/</g, '\\u003c');
 +
 +		return `<!DOCTYPE html>
 +				<html lang="en">
@@ -779,6 +818,8 @@ Index: product-integrator/lib/vscode/src/vs/workbench/browser/parts/editor/wso2E
 +					<div id="root"></div>
 +					<script>
 +						window.__WI_BRIDGE_BOOTSTRAP = ${serializedBootstrap};
++						window.__WI_BI_FORM_REMOTE = ${serializedBiFormRemote};
++						window.__WI_BI_FORM_REMOTE_STATE = ${serializedBiFormRemoteState};
 +						window.__WI_EMBEDDED_WELCOME_HIDE_LOADER = function () {
 +							document.body.classList.add('embedded-welcome-ready');
 +						};

--- a/patches/packageResources.diff
+++ b/patches/packageResources.diff
@@ -14,3 +14,24 @@ Index: product-integrator/lib/vscode/build/gulpfile.vscode.ts
  	'out-build/vs/workbench/contrib/debug/browser/media/*.png',
  
  	// External Terminal
+Index: product-integrator/lib/vscode/build/next/index.ts
+===================================================================
+--- product-integrator.orig/lib/vscode/build/next/index.ts
++++ product-integrator/lib/vscode/build/next/index.ts
+@@ -243,9 +243,13 @@
+ 	'vs/editor/common/languages/highlights/*.scm',
+ 	'vs/editor/common/languages/injections/*.scm',
+ 
+-	// SVGs referenced from CSS (needed for transpile/dev builds where CSS is copied as-is)
+-	'vs/workbench/browser/media/code-icon.svg',
+-	'vs/workbench/browser/parts/editor/media/letterpress*.svg',
++	// SVGs referenced from CSS (needed for transpile/dev builds where CSS is copied as-is).
++	// WSO2: widened from code-icon.svg / letterpress*.svg so that the branded SVGs layered in
++	// from the product `resources/vscode` overlay (e.g. integrator-activity-icon-dark.svg, used
++	// by the WSO2 login dialog) are packaged too. Referenced from TS via FileAccess, not CSS,
++	// so esbuild does not pick them up on its own.
++	'vs/workbench/browser/media/*.svg',
++	'vs/workbench/browser/parts/editor/media/*.svg',
+ 	'vs/sessions/contrib/chat/browser/media/*.svg',
+ 	'vs/sessions/contrib/welcome/browser/media/themePreviews/*.svg'
+ ];

--- a/patches/series
+++ b/patches/series
@@ -19,3 +19,4 @@ disableAgentSessions.diff
 skipCopilotRipgrepShim.diff
 coreCiSerializeBundles.diff
 increaseHeap.diff
+windowsSigntoolOptional.diff

--- a/patches/series
+++ b/patches/series
@@ -8,7 +8,6 @@ packageResources.diff
 wso2-font-pkg-update
 disableAiFeatures.diff
 removeCopilotStatusBar.diff
-increaseHeap.diff
 skip-extension-outdated-test.diff
 disableVsixChecksumCheck.diff
 disableWorkspaceTrust.diff
@@ -18,3 +17,5 @@ integratorMenus.diff
 removeXmlLanguageAssociation.diff
 disableAgentSessions.diff
 skipCopilotRipgrepShim.diff
+coreCiSerializeBundles.diff
+increaseHeap.diff

--- a/patches/windowsSigntoolOptional.diff
+++ b/patches/windowsSigntoolOptional.diff
@@ -1,0 +1,23 @@
+Index: product-integrator/lib/vscode/build/gulpfile.vscode.ts
+===================================================================
+--- product-integrator.orig/lib/vscode/build/gulpfile.vscode.ts
++++ product-integrator/lib/vscode/build/gulpfile.vscode.ts
+@@ -534,7 +534,17 @@ function packageTask(platform: string, arch: string, sourceFolderName: string, d
+ function hasAuthenticodeSignature(filePath: string): Promise<boolean> {
+ 	return new Promise((resolve, reject) => {
+ 		const proc = cp.spawn('signtool.exe', ['verify', '/pa', filePath]);
+-		proc.on('error', reject);
++		proc.on('error', (err: NodeJS.ErrnoException) => {
++			// signtool.exe ships with the Windows SDK and may not be on PATH (e.g. the
++			// WSO2 CI runners). It is only used to strip Microsoft ESRP signatures, which
++			// WSO2 builds do not produce, so treat "not found" as "no signature present"
++			// and skip the strip rather than failing the whole build.
++			if (err.code === 'ENOENT') {
++				resolve(false);
++			} else {
++				reject(err);
++			}
++		});
+ 		proc.on('exit', code => resolve(code === 0));
+ 	});
+ }


### PR DESCRIPTION
## Purpose

Getting the daily/release pipeline green landed a mix of changes on `dailyBuild`. This PR isolates the **source-level patches** — the ones that change what actually gets built and shipped — plus the one workflow fix that the patch changes depend on, so they can be read on their own instead of buried in workflow churn.

`dailyBuild` is unchanged — this is an extraction for review, intended to be rebased once agreed.

## Base

Branched from `4249eb6` (the `dailyBuild` state after the VS Code 1.127.0 base bump, before the pipeline work began). That base is deliberate: the patches apply against 1.127.0 sources, and branching from `main` instead would make the `patches/series` diff drag in the unrelated 1.127.0 series entries.

## Changes

**6 files, +88/-2.**

### `10d111a` — Serialize core-ci bundling, re-apply heap caps
> Closes items **1** and **2** of #NNN.

New `patches/coreCiSerializeBundles.diff` flips `task.parallel` → `task.series` in `lib/vscode/build/gulpfile.vscode.ts` for the three minified bundles (`out-vscode-min`, `out-vscode-reh-min`, `out-vscode-reh-web-min`), so only one esbuild minify bundle runs at a time.

`patches/series` also moves the pre-existing `increaseHeap.diff` to the end of the series, so the `--max-old-space-size` caps on the validation checkers (`tsec-compile-check`, `valid-layers-check`, `define-class-fields-check`) apply on top of the serialized bundling. `increaseHeap.diff` itself is untouched — only its position changes.

**Cost:** serial bundling is slower, and only fits because the cold build timeout was raised on the workflow side — that timeout change is *not* in this PR, so this branch alone would still time out on a cold build. Tracked as a follow-up on #NNN.

### `edbb970` — Make Windows Authenticode strip optional
> Closes item **3** of #NNN.

New `patches/windowsSigntoolOptional.diff`. `hasAuthenticodeSignature()` previously spawned `signtool.exe` and rejected on any spawn error, so packaging failed outright on runners without the Windows SDK on PATH. Now `ENOENT` resolves to `false` — treated as "no signature present" — while every other error still rejects. Genuine signtool failures (bad signature, permission errors) fail exactly as before.

Because our builds never produce Microsoft ESRP signatures, skipping the strip is a no-op for output correctness rather than a workaround hiding a real signing problem.

### `138538b` — Package the branded WSO2 SVGs
> Closes item **4** of #NNN — the only user-visible product fix in this PR.

`patches/packageResources.diff` widens two globs in `lib/vscode/build/next/index.ts`:

- `vs/workbench/browser/media/code-icon.svg` → `vs/workbench/browser/media/*.svg`
- `vs/workbench/browser/parts/editor/media/letterpress*.svg` → `.../media/*.svg`

The branded SVGs layered in from the `resources/vscode` overlay — e.g. `integrator-activity-icon-dark.svg`, used by the WSO2 login dialog — are referenced from TypeScript via `FileAccess` rather than from CSS, so esbuild does not discover them and they were silently dropped from the package. This is what fixes the missing WSO2 logo in the login dialog.

### `f602d83` — Disable RPM auto-strip
> Closes item **5** of #NNN.

Adds `%global __os_install_post %{nil}` to `installers/linux-rpm/wso2-integrator.spec`.

`resources/app/node_modules/@microsoft/mxc-sdk` ships prebuilt cross-platform binaries (`bin/arm64/*`). The x86_64 build host's `strip` cannot parse those ARM64 ELF files and aborts the `%install` phase. Electron/Node binaries must not be stripped anyway, and the deb packaging already does not auto-strip — so this aligns RPM with deb rather than introducing a divergence.

**Cost:** the RPM is larger, since nothing in it gets stripped now.

### `ade5715` — Refresh the apt index before caching packages

`.github/workflows/compile.yml`: adds `sudo apt-get update` ahead of `cache-apt-pkgs-action`, bumps its cache `version` from `1.0` to `1.1`, and adds a post-install check that `quilt` and `g++` are actually on PATH.

The runner image ships a pinned apt index. Once the archive supersedes a package (e.g. a krb5 security update), the old `.deb` leaves the pool and the stale index 404s. The action does not refresh the index itself, and on fetch failure it still saved an empty (~2 KB) cache under the old key — so every later run got a cache *hit* that installed nothing and failed downstream with `quilt: command not found`. The version bump discards those poisoned caches; the verification step makes the failure loud and immediate instead of surfacing three steps later.

This is the one workflow change in the PR: without `quilt` present, none of the patches above apply at all, so it can't sensibly be split into the workflow follow-up.

## Not included

`patches/gettingStarted.diff` (Ballerina federated BI form in the embedded welcome) was on this branch and has been **reverted out** (`9b51bc2` reverts `b508ea5`), so the file is byte-identical to the base again and does not appear in this diff. It's a product patch that landed on its own and will be raised separately.

## Review notes

- Only item 4 (`packageResources.diff`) is a product-behaviour fix. Items 1–3 are build-infrastructure workarounds that live in `patches/` because that is where code-oss changes have to go, and each one is a patch we must re-apply on every VS Code base bump. Their permanent fixes are follow-ups on #NNN.
- Each commit is independently revertable; `f602d83` and `ade5715` in particular are orthogonal to the other three.

## Verification

`git diff <this-branch> dailyBuild -- patches installers/` is empty — these files are byte-identical to the `dailyBuild` state that produced the green pipeline.

That is the whole of the evidence. The patches have not been re-applied or built in isolation on this branch, and no pipeline run has been done against it; an independent run is a follow-up on #NNN.
