### PR TITLE
Unblock the pipeline: cold-build timeout, memory-grouped validation checks, extensions cache fallback

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -221,12 +221,13 @@ jobs:
             lib/vscode/.build/builtInExtensions
             lib/vscode/.build/extensions
           key: extensions-shared-${{ inputs.ballerina_extension_source }}-${{ needs.resolve-versions.outputs.ballerina_extension_version }}-${{ inputs.mi_extension_source }}-${{ needs.resolve-versions.outputs.mi_extension_version }}-${{ hashFiles('patches/*.diff', 'ci/build/update-product.sh', 'ci/build/component-versions.properties', 'lib/vscode/package.json', 'wi/**') }}
-          # Partial restore so a cold key doesn't mean a cold cache. download-builtin-extensions
-          # re-validates versions (isUpToDate) and re-downloads only what actually changed, so a
-          # prefix-restored cache stays correct.
+          # Partial restore so a cold key doesn't mean a cold cache: this prefix keeps the component
+          # versions fixed and only drops the patch/wi/** hash, which is the churn we are absorbing.
+          # download-builtin-extensions then re-validates each extension by version string
+          # (isUpToDate) -- see the wso2.wso2-integrator removal in "Install builtin extensions" for
+          # the one extension that check cannot catch.
           restore-keys: |
             extensions-shared-${{ inputs.ballerina_extension_source }}-${{ needs.resolve-versions.outputs.ballerina_extension_version }}-${{ inputs.mi_extension_source }}-
-            extensions-shared-${{ inputs.ballerina_extension_source }}-
 
       - name: Download compilation artifact
         uses: actions/download-artifact@v4
@@ -317,6 +318,13 @@ jobs:
             echo "✅ Extensions cache hit - using shared cached extensions"
           else
             echo "⬇️ Downloading built-in extensions"
+            # wso2.wso2-integrator is pinned in product.json to the hand-bumped version in
+            # wi/wi-extension/package.json, which does not move when wi/** content changes.
+            # isUpToDate() (lib/vscode/build/lib/builtInExtensions.ts) compares only that version
+            # string, so a prefix-restored copy would be judged current and the vsix just built
+            # would never be unpacked. Reaching this branch means the exact key missed, so drop it
+            # and force a re-unpack.
+            rm -rf .build/builtInExtensions/wso2.wso2-integrator
             npm run download-builtin-extensions
           fi
 
@@ -569,12 +577,13 @@ jobs:
             lib/vscode/.build/builtInExtensions
             lib/vscode/.build/extensions
           key: extensions-shared-${{ inputs.ballerina_extension_source }}-${{ needs.resolve-versions.outputs.ballerina_extension_version }}-${{ inputs.mi_extension_source }}-${{ needs.resolve-versions.outputs.mi_extension_version }}-${{ hashFiles('patches/*.diff', 'ci/build/update-product.sh', 'ci/build/component-versions.properties', 'lib/vscode/package.json', 'wi/**') }}
-          # Partial restore so a cold key doesn't mean a cold cache. download-builtin-extensions
-          # re-validates versions (isUpToDate) and re-downloads only what actually changed, so a
-          # prefix-restored cache stays correct.
+          # Partial restore so a cold key doesn't mean a cold cache: this prefix keeps the component
+          # versions fixed and only drops the patch/wi/** hash, which is the churn we are absorbing.
+          # download-builtin-extensions then re-validates each extension by version string
+          # (isUpToDate) -- see the wso2.wso2-integrator removal in "Install builtin extensions" for
+          # the one extension that check cannot catch.
           restore-keys: |
             extensions-shared-${{ inputs.ballerina_extension_source }}-${{ needs.resolve-versions.outputs.ballerina_extension_version }}-${{ inputs.mi_extension_source }}-
-            extensions-shared-${{ inputs.ballerina_extension_source }}-
 
       - name: Download compilation artifact
         uses: actions/download-artifact@v4
@@ -705,6 +714,13 @@ jobs:
             echo "✅ Extensions cache hit - using shared cached extensions"
           else
             echo "⬇️ Downloading built-in extensions"
+            # wso2.wso2-integrator is pinned in product.json to the hand-bumped version in
+            # wi/wi-extension/package.json, which does not move when wi/** content changes.
+            # isUpToDate() (lib/vscode/build/lib/builtInExtensions.ts) compares only that version
+            # string, so a prefix-restored copy would be judged current and the vsix just built
+            # would never be unpacked. Reaching this branch means the exact key missed, so drop it
+            # and force a re-unpack.
+            rm -rf .build/builtInExtensions/wso2.wso2-integrator
             npm run download-builtin-extensions
           fi
 

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -222,13 +222,18 @@ jobs:
             lib/vscode/.build/extensions
           key: extensions-shared-${{ inputs.ballerina_extension_source }}-${{ needs.resolve-versions.outputs.ballerina_extension_version }}-${{ inputs.mi_extension_source }}-${{ needs.resolve-versions.outputs.mi_extension_version }}-${{ hashFiles('patches/*.diff', 'ci/build/update-product.sh', 'ci/build/component-versions.properties', 'lib/vscode/package.json', 'wi/**') }}
           # Partial restore so a cold key doesn't mean a cold cache: this prefix is the exact key minus
-          # the file-hash component, so a patch or wi/** edit falls back to the previous run at the same
-          # component versions -- which is the churn being absorbed. The version components stay pinned
-          # deliberately: dropping them would let a restore cross a component upgrade, and while
-          # download-builtin-extensions re-validates by version string (isUpToDate) and would re-fetch,
-          # a fallback that crosses versions is harder to reason about than the cache it saves is worth.
-          # See the wso2.wso2-integrator removal in "Install builtin extensions" for the one extension
-          # that check cannot catch.
+          # the file-hash component, so a patch or wi/** edit falls back to the previous run instead of
+          # re-downloading every extension.
+          #
+          # What the fallback does and does not hold fixed, since it is not uniform: Ballerina and MI
+          # have their own key fields -- they are the two with a marketplace-vs-vsix source switch, and
+          # the version came along with the switch -- so a fallback cannot cross their versions. The
+          # streaming-integrator, hurl-client and mcp-server-inspector versions live only inside the
+          # dropped hash, so a fallback CAN cross those, as it can WI's. That is safe but not free:
+          # download-builtin-extensions re-validates by version string (isUpToDate), which catches those
+          # three because their versions move when their contents do. It cannot catch WI, whose version
+          # is hand-bumped and stays constant across content changes -- hence the explicit removal in
+          # "Install builtin extensions" below.
           restore-keys: |
             extensions-shared-${{ inputs.ballerina_extension_source }}-${{ needs.resolve-versions.outputs.ballerina_extension_version }}-${{ inputs.mi_extension_source }}-${{ needs.resolve-versions.outputs.mi_extension_version }}-
 
@@ -581,13 +586,18 @@ jobs:
             lib/vscode/.build/extensions
           key: extensions-shared-${{ inputs.ballerina_extension_source }}-${{ needs.resolve-versions.outputs.ballerina_extension_version }}-${{ inputs.mi_extension_source }}-${{ needs.resolve-versions.outputs.mi_extension_version }}-${{ hashFiles('patches/*.diff', 'ci/build/update-product.sh', 'ci/build/component-versions.properties', 'lib/vscode/package.json', 'wi/**') }}
           # Partial restore so a cold key doesn't mean a cold cache: this prefix is the exact key minus
-          # the file-hash component, so a patch or wi/** edit falls back to the previous run at the same
-          # component versions -- which is the churn being absorbed. The version components stay pinned
-          # deliberately: dropping them would let a restore cross a component upgrade, and while
-          # download-builtin-extensions re-validates by version string (isUpToDate) and would re-fetch,
-          # a fallback that crosses versions is harder to reason about than the cache it saves is worth.
-          # See the wso2.wso2-integrator removal in "Install builtin extensions" for the one extension
-          # that check cannot catch.
+          # the file-hash component, so a patch or wi/** edit falls back to the previous run instead of
+          # re-downloading every extension.
+          #
+          # What the fallback does and does not hold fixed, since it is not uniform: Ballerina and MI
+          # have their own key fields -- they are the two with a marketplace-vs-vsix source switch, and
+          # the version came along with the switch -- so a fallback cannot cross their versions. The
+          # streaming-integrator, hurl-client and mcp-server-inspector versions live only inside the
+          # dropped hash, so a fallback CAN cross those, as it can WI's. That is safe but not free:
+          # download-builtin-extensions re-validates by version string (isUpToDate), which catches those
+          # three because their versions move when their contents do. It cannot catch WI, whose version
+          # is hand-bumped and stays constant across content changes -- hence the explicit removal in
+          # "Install builtin extensions" below.
           restore-keys: |
             extensions-shared-${{ inputs.ballerina_extension_source }}-${{ needs.resolve-versions.outputs.ballerina_extension_version }}-${{ inputs.mi_extension_source }}-${{ needs.resolve-versions.outputs.mi_extension_version }}-
 

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -221,6 +221,12 @@ jobs:
             lib/vscode/.build/builtInExtensions
             lib/vscode/.build/extensions
           key: extensions-shared-${{ inputs.ballerina_extension_source }}-${{ needs.resolve-versions.outputs.ballerina_extension_version }}-${{ inputs.mi_extension_source }}-${{ needs.resolve-versions.outputs.mi_extension_version }}-${{ hashFiles('patches/*.diff', 'ci/build/update-product.sh', 'ci/build/component-versions.properties', 'lib/vscode/package.json', 'wi/**') }}
+          # Partial restore so a cold key doesn't mean a cold cache. download-builtin-extensions
+          # re-validates versions (isUpToDate) and re-downloads only what actually changed, so a
+          # prefix-restored cache stays correct.
+          restore-keys: |
+            extensions-shared-${{ inputs.ballerina_extension_source }}-${{ needs.resolve-versions.outputs.ballerina_extension_version }}-${{ inputs.mi_extension_source }}-
+            extensions-shared-${{ inputs.ballerina_extension_source }}-
 
       - name: Download compilation artifact
         uses: actions/download-artifact@v4
@@ -563,6 +569,12 @@ jobs:
             lib/vscode/.build/builtInExtensions
             lib/vscode/.build/extensions
           key: extensions-shared-${{ inputs.ballerina_extension_source }}-${{ needs.resolve-versions.outputs.ballerina_extension_version }}-${{ inputs.mi_extension_source }}-${{ needs.resolve-versions.outputs.mi_extension_version }}-${{ hashFiles('patches/*.diff', 'ci/build/update-product.sh', 'ci/build/component-versions.properties', 'lib/vscode/package.json', 'wi/**') }}
+          # Partial restore so a cold key doesn't mean a cold cache. download-builtin-extensions
+          # re-validates versions (isUpToDate) and re-downloads only what actually changed, so a
+          # prefix-restored cache stays correct.
+          restore-keys: |
+            extensions-shared-${{ inputs.ballerina_extension_source }}-${{ needs.resolve-versions.outputs.ballerina_extension_version }}-${{ inputs.mi_extension_source }}-
+            extensions-shared-${{ inputs.ballerina_extension_source }}-
 
       - name: Download compilation artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -221,13 +221,16 @@ jobs:
             lib/vscode/.build/builtInExtensions
             lib/vscode/.build/extensions
           key: extensions-shared-${{ inputs.ballerina_extension_source }}-${{ needs.resolve-versions.outputs.ballerina_extension_version }}-${{ inputs.mi_extension_source }}-${{ needs.resolve-versions.outputs.mi_extension_version }}-${{ hashFiles('patches/*.diff', 'ci/build/update-product.sh', 'ci/build/component-versions.properties', 'lib/vscode/package.json', 'wi/**') }}
-          # Partial restore so a cold key doesn't mean a cold cache: this prefix keeps the component
-          # versions fixed and only drops the patch/wi/** hash, which is the churn we are absorbing.
-          # download-builtin-extensions then re-validates each extension by version string
-          # (isUpToDate) -- see the wso2.wso2-integrator removal in "Install builtin extensions" for
-          # the one extension that check cannot catch.
+          # Partial restore so a cold key doesn't mean a cold cache: this prefix is the exact key minus
+          # the file-hash component, so a patch or wi/** edit falls back to the previous run at the same
+          # component versions -- which is the churn being absorbed. The version components stay pinned
+          # deliberately: dropping them would let a restore cross a component upgrade, and while
+          # download-builtin-extensions re-validates by version string (isUpToDate) and would re-fetch,
+          # a fallback that crosses versions is harder to reason about than the cache it saves is worth.
+          # See the wso2.wso2-integrator removal in "Install builtin extensions" for the one extension
+          # that check cannot catch.
           restore-keys: |
-            extensions-shared-${{ inputs.ballerina_extension_source }}-${{ needs.resolve-versions.outputs.ballerina_extension_version }}-${{ inputs.mi_extension_source }}-
+            extensions-shared-${{ inputs.ballerina_extension_source }}-${{ needs.resolve-versions.outputs.ballerina_extension_version }}-${{ inputs.mi_extension_source }}-${{ needs.resolve-versions.outputs.mi_extension_version }}-
 
       - name: Download compilation artifact
         uses: actions/download-artifact@v4
@@ -577,13 +580,16 @@ jobs:
             lib/vscode/.build/builtInExtensions
             lib/vscode/.build/extensions
           key: extensions-shared-${{ inputs.ballerina_extension_source }}-${{ needs.resolve-versions.outputs.ballerina_extension_version }}-${{ inputs.mi_extension_source }}-${{ needs.resolve-versions.outputs.mi_extension_version }}-${{ hashFiles('patches/*.diff', 'ci/build/update-product.sh', 'ci/build/component-versions.properties', 'lib/vscode/package.json', 'wi/**') }}
-          # Partial restore so a cold key doesn't mean a cold cache: this prefix keeps the component
-          # versions fixed and only drops the patch/wi/** hash, which is the churn we are absorbing.
-          # download-builtin-extensions then re-validates each extension by version string
-          # (isUpToDate) -- see the wso2.wso2-integrator removal in "Install builtin extensions" for
-          # the one extension that check cannot catch.
+          # Partial restore so a cold key doesn't mean a cold cache: this prefix is the exact key minus
+          # the file-hash component, so a patch or wi/** edit falls back to the previous run at the same
+          # component versions -- which is the churn being absorbed. The version components stay pinned
+          # deliberately: dropping them would let a restore cross a component upgrade, and while
+          # download-builtin-extensions re-validates by version string (isUpToDate) and would re-fetch,
+          # a fallback that crosses versions is harder to reason about than the cache it saves is worth.
+          # See the wso2.wso2-integrator removal in "Install builtin extensions" for the one extension
+          # that check cannot catch.
           restore-keys: |
-            extensions-shared-${{ inputs.ballerina_extension_source }}-${{ needs.resolve-versions.outputs.ballerina_extension_version }}-${{ inputs.mi_extension_source }}-
+            extensions-shared-${{ inputs.ballerina_extension_source }}-${{ needs.resolve-versions.outputs.ballerina_extension_version }}-${{ inputs.mi_extension_source }}-${{ needs.resolve-versions.outputs.mi_extension_version }}-
 
       - name: Download compilation artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -192,13 +192,18 @@ jobs:
             lib/vscode/.build/extensions
           key: extensions-shared-${{ inputs.ballerina_extension_source }}-${{ needs.resolve-versions.outputs.ballerina_extension_version }}-${{ inputs.mi_extension_source }}-${{ needs.resolve-versions.outputs.mi_extension_version }}-${{ hashFiles('patches/*.diff', 'ci/build/update-product.sh', 'ci/build/component-versions.properties', 'lib/vscode/package.json', 'wi/**') }}
           # Partial restore so a cold key doesn't mean a cold cache: this prefix is the exact key minus
-          # the file-hash component, so a patch or wi/** edit falls back to the previous run at the same
-          # component versions -- which is the churn being absorbed. The version components stay pinned
-          # deliberately: dropping them would let a restore cross a component upgrade, and while
-          # download-builtin-extensions re-validates by version string (isUpToDate) and would re-fetch,
-          # a fallback that crosses versions is harder to reason about than the cache it saves is worth.
-          # See the wso2.wso2-integrator removal in "Install builtin extensions" for the one extension
-          # that check cannot catch.
+          # the file-hash component, so a patch or wi/** edit falls back to the previous run instead of
+          # re-downloading every extension.
+          #
+          # What the fallback does and does not hold fixed, since it is not uniform: Ballerina and MI
+          # have their own key fields -- they are the two with a marketplace-vs-vsix source switch, and
+          # the version came along with the switch -- so a fallback cannot cross their versions. The
+          # streaming-integrator, hurl-client and mcp-server-inspector versions live only inside the
+          # dropped hash, so a fallback CAN cross those, as it can WI's. That is safe but not free:
+          # download-builtin-extensions re-validates by version string (isUpToDate), which catches those
+          # three because their versions move when their contents do. It cannot catch WI, whose version
+          # is hand-bumped and stays constant across content changes -- hence the explicit removal in
+          # "Install builtin extensions" below.
           restore-keys: |
             extensions-shared-${{ inputs.ballerina_extension_source }}-${{ needs.resolve-versions.outputs.ballerina_extension_version }}-${{ inputs.mi_extension_source }}-${{ needs.resolve-versions.outputs.mi_extension_version }}-
 

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -191,12 +191,13 @@ jobs:
             lib/vscode/.build/builtInExtensions
             lib/vscode/.build/extensions
           key: extensions-shared-${{ inputs.ballerina_extension_source }}-${{ needs.resolve-versions.outputs.ballerina_extension_version }}-${{ inputs.mi_extension_source }}-${{ needs.resolve-versions.outputs.mi_extension_version }}-${{ hashFiles('patches/*.diff', 'ci/build/update-product.sh', 'ci/build/component-versions.properties', 'lib/vscode/package.json', 'wi/**') }}
-          # Partial restore so a cold key doesn't mean a cold cache. download-builtin-extensions
-          # re-validates versions (isUpToDate) and re-downloads only what actually changed, so a
-          # prefix-restored cache stays correct.
+          # Partial restore so a cold key doesn't mean a cold cache: this prefix keeps the component
+          # versions fixed and only drops the patch/wi/** hash, which is the churn we are absorbing.
+          # download-builtin-extensions then re-validates each extension by version string
+          # (isUpToDate) -- see the wso2.wso2-integrator removal in "Install builtin extensions" for
+          # the one extension that check cannot catch.
           restore-keys: |
             extensions-shared-${{ inputs.ballerina_extension_source }}-${{ needs.resolve-versions.outputs.ballerina_extension_version }}-${{ inputs.mi_extension_source }}-
-            extensions-shared-${{ inputs.ballerina_extension_source }}-
 
       - name: Cache Rust toolchain
         uses: actions/cache@v4
@@ -360,6 +361,13 @@ jobs:
             echo "✅ Extensions cache hit - using cached extensions"
           else
             echo "⬇️ Downloading built-in extensions"
+            # wso2.wso2-integrator is pinned in product.json to the hand-bumped version in
+            # wi/wi-extension/package.json, which does not move when wi/** content changes.
+            # isUpToDate() (lib/vscode/build/lib/builtInExtensions.ts) compares only that version
+            # string, so a prefix-restored copy would be judged current and the vsix just built
+            # would never be unpacked. Reaching this branch means the exact key missed, so drop it
+            # and force a re-unpack.
+            rm -rf .build/builtInExtensions/wso2.wso2-integrator
             npm run download-builtin-extensions
           fi
 
@@ -371,16 +379,20 @@ jobs:
             echo "✅ TypeScript cache hit - using cached compilation"
             echo "Skipping core compilation, running validation only"
             npm run compile-extensions-build
-            npm exec -- npm-run-all --max-parallel 1 -lp eslint valid-layers-check define-class-fields-check vscode-dts-compile-check tsec-compile-check
+            npm exec -- npm-run-all -lp eslint vscode-dts-compile-check
+            npm exec -- npm-run-all -ls valid-layers-check define-class-fields-check tsec-compile-check
           else
             echo "❌ TypeScript cache miss - full compilation required"
             echo "Running complete compilation pipeline"
             npm run core-ci
-            # Run the validation checks serially (--max-parallel 1). Several carry large
-            # --max-old-space-size caps (define-class-fields and tsec use 8192 MB each);
-            # two 8 GB checks at once exceed the 14 GB runner and the kernel OOM-kills one
-            # (exit 137). Serial keeps peak memory to a single check at a time.
-            npm exec -- npm-run-all --max-parallel 1 -lp eslint valid-layers-check define-class-fields-check vscode-dts-compile-check tsec-compile-check
+            # patches/increaseHeap.diff caps the node heap for three of these five checks:
+            # tsec-compile-check at 8192 MB, define-class-fields-check at 4096 then 8192, and
+            # valid-layers-check at 4096. Running two capped checks at once exceeds the runner and
+            # the kernel OOM-kills one, surfacing as a bare exit 137 with no useful log. So the
+            # three capped checks run serially (-ls) and only the two uncapped ones -- eslint and
+            # vscode-dts-compile-check, the latter being tsgo -- run in parallel.
+            npm exec -- npm-run-all -lp eslint vscode-dts-compile-check
+            npm exec -- npm-run-all -ls valid-layers-check define-class-fields-check tsec-compile-check
           fi
 
       - name: Compress compilation artifact

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -114,7 +114,10 @@ jobs:
   compile:
     needs: resolve-versions
     name: Build repo
-    timeout-minutes: 45
+    # 90 gives a fully cold-cache build room to finish and reach the post-step that SAVES the
+    # caches; warm runs finish well under this. 45 was too tight for a cold build, and a
+    # timeout there cancels the job before caches are saved -> every run stays cold (vicious cycle).
+    timeout-minutes: 90
     runs-on: ${{ inputs.runOnAWS && inputs.awsRunnerId || 'ubuntu-latest' }}
     defaults:
       run:
@@ -188,6 +191,12 @@ jobs:
             lib/vscode/.build/builtInExtensions
             lib/vscode/.build/extensions
           key: extensions-shared-${{ inputs.ballerina_extension_source }}-${{ needs.resolve-versions.outputs.ballerina_extension_version }}-${{ inputs.mi_extension_source }}-${{ needs.resolve-versions.outputs.mi_extension_version }}-${{ hashFiles('patches/*.diff', 'ci/build/update-product.sh', 'ci/build/component-versions.properties', 'lib/vscode/package.json', 'wi/**') }}
+          # Partial restore so a cold key doesn't mean a cold cache. download-builtin-extensions
+          # re-validates versions (isUpToDate) and re-downloads only what actually changed, so a
+          # prefix-restored cache stays correct.
+          restore-keys: |
+            extensions-shared-${{ inputs.ballerina_extension_source }}-${{ needs.resolve-versions.outputs.ballerina_extension_version }}-${{ inputs.mi_extension_source }}-
+            extensions-shared-${{ inputs.ballerina_extension_source }}-
 
       - name: Cache Rust toolchain
         uses: actions/cache@v4
@@ -321,6 +330,12 @@ jobs:
 
       - name: Build WI extension
         working-directory: .
+        env:
+          # The wso2-integrator build downloads Choreo CLI binaries from the GitHub API
+          # (scripts/download-choreo-cli.js). Without a token those calls are unauthenticated
+          # and hit the 60 req/hour limit -> "HTTP 403: rate limit exceeded". Authenticate to
+          # raise the limit to 5000/hour, matching the other steps in this job.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node common/scripts/install-run-rush.js build --verbose
 
@@ -356,12 +371,16 @@ jobs:
             echo "✅ TypeScript cache hit - using cached compilation"
             echo "Skipping core compilation, running validation only"
             npm run compile-extensions-build
-            npm exec -- npm-run-all -lp eslint valid-layers-check define-class-fields-check vscode-dts-compile-check tsec-compile-check
+            npm exec -- npm-run-all --max-parallel 1 -lp eslint valid-layers-check define-class-fields-check vscode-dts-compile-check tsec-compile-check
           else
             echo "❌ TypeScript cache miss - full compilation required"
             echo "Running complete compilation pipeline"
             npm run core-ci
-            npm exec -- npm-run-all -lp eslint valid-layers-check define-class-fields-check vscode-dts-compile-check tsec-compile-check
+            # Run the validation checks serially (--max-parallel 1). Several carry large
+            # --max-old-space-size caps (define-class-fields and tsec use 8192 MB each);
+            # two 8 GB checks at once exceed the 14 GB runner and the kernel OOM-kills one
+            # (exit 137). Serial keeps peak memory to a single check at a time.
+            npm exec -- npm-run-all --max-parallel 1 -lp eslint valid-layers-check define-class-fields-check vscode-dts-compile-check tsec-compile-check
           fi
 
       - name: Compress compilation artifact

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -191,13 +191,16 @@ jobs:
             lib/vscode/.build/builtInExtensions
             lib/vscode/.build/extensions
           key: extensions-shared-${{ inputs.ballerina_extension_source }}-${{ needs.resolve-versions.outputs.ballerina_extension_version }}-${{ inputs.mi_extension_source }}-${{ needs.resolve-versions.outputs.mi_extension_version }}-${{ hashFiles('patches/*.diff', 'ci/build/update-product.sh', 'ci/build/component-versions.properties', 'lib/vscode/package.json', 'wi/**') }}
-          # Partial restore so a cold key doesn't mean a cold cache: this prefix keeps the component
-          # versions fixed and only drops the patch/wi/** hash, which is the churn we are absorbing.
-          # download-builtin-extensions then re-validates each extension by version string
-          # (isUpToDate) -- see the wso2.wso2-integrator removal in "Install builtin extensions" for
-          # the one extension that check cannot catch.
+          # Partial restore so a cold key doesn't mean a cold cache: this prefix is the exact key minus
+          # the file-hash component, so a patch or wi/** edit falls back to the previous run at the same
+          # component versions -- which is the churn being absorbed. The version components stay pinned
+          # deliberately: dropping them would let a restore cross a component upgrade, and while
+          # download-builtin-extensions re-validates by version string (isUpToDate) and would re-fetch,
+          # a fallback that crosses versions is harder to reason about than the cache it saves is worth.
+          # See the wso2.wso2-integrator removal in "Install builtin extensions" for the one extension
+          # that check cannot catch.
           restore-keys: |
-            extensions-shared-${{ inputs.ballerina_extension_source }}-${{ needs.resolve-versions.outputs.ballerina_extension_version }}-${{ inputs.mi_extension_source }}-
+            extensions-shared-${{ inputs.ballerina_extension_source }}-${{ needs.resolve-versions.outputs.ballerina_extension_version }}-${{ inputs.mi_extension_source }}-${{ needs.resolve-versions.outputs.mi_extension_version }}-
 
       - name: Cache Rust toolchain
         uses: actions/cache@v4

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -150,12 +150,16 @@ jobs:
           set +e
           mkdir -p editor-logs
           # code-oss writes per-session logs (main.log, exthost.log, per-extension output) under
-          # its user-data-dir. We don't know the exact dir wso2ipw uses, so search likely roots.
-          for root in "$HOME/.wso2ipw" "$HOME/.config" "$HOME/.wso2-integrator" "$HOME/.vscode-oss"; do
-            [ -d "$root" ] || continue
-            find "$root" -type f \( -name "*.log" -o -name "*.err" \) 2>/dev/null \
-              -exec cp --parents {} editor-logs/ \; 2>/dev/null
-          done
+          # <user-data-dir>/logs. The user-data-dir is not a guess: main.ts passes
+          # product.nameShort to getUserDataPath(), and getDefaultUserDataPath() joins it onto
+          # $XDG_CONFIG_HOME (or ~/.config) on Linux. nameShort is set in ci/build/update-product.sh.
+          # Copying only that tree keeps unrelated logs out of the artifact.
+          USER_DATA="${XDG_CONFIG_HOME:-$HOME/.config}/WSO2 Integrator"
+          if [ -d "${USER_DATA}/logs" ]; then
+            cp -R "${USER_DATA}/logs" editor-logs/
+          else
+            echo "No log directory at ${USER_DATA}/logs"
+          fi
           echo "Collected log files:"; find editor-logs -type f 2>/dev/null || true
 
       - name: Upload editor logs on failure
@@ -165,6 +169,7 @@ jobs:
           name: smoke-test-editor-logs-${{ matrix.example }}-linux
           path: editor-logs/**
           if-no-files-found: warn
+          retention-days: 7
 
       - name: Upload logs on failure
         if: failure()
@@ -268,18 +273,25 @@ jobs:
 
       - name: Collect editor logs on failure
         if: failure()
-        shell: bash
+        # pwsh, not bash: $env:APPDATA is a Windows path, and Git Bash cannot test or traverse it
+        # without cygpath. The rest of this job's native steps already use pwsh.
+        shell: pwsh
         run: |
-          set +e
-          mkdir -p editor-logs
-          # code-oss writes per-session logs (main.log, exthost.log, per-extension output) under
-          # its user-data-dir. We don't know the exact dir wso2ipw uses, so search likely roots.
-          for root in "$USERPROFILE/.wso2ipw" "$APPDATA" "$USERPROFILE/.wso2-integrator"; do
-            [ -d "$root" ] || continue
-            find "$root" -type f \( -name "*.log" -o -name "*.err" \) 2>/dev/null \
-              -exec cp --parents {} editor-logs/ \; 2>/dev/null
-          done
-          echo "Collected log files:"; find editor-logs -type f 2>/dev/null || true
+          # Same path as the Linux collector, via getDefaultUserDataPath()'s win32 branch:
+          # $APPDATA joined with product.nameShort ("WSO2 Integrator", set in update-product.sh).
+          $logs = Join-Path $env:APPDATA 'WSO2 Integrator\logs'
+          New-Item -ItemType Directory -Path editor-logs -Force | Out-Null
+          if (Test-Path $logs) {
+            # SilentlyContinue for the same reason the Linux collector uses `set +e`: GitHub runs
+            # pwsh steps with $ErrorActionPreference='stop', and a locked log file must not turn
+            # diagnostics collection into a second failure.
+            Copy-Item $logs -Destination editor-logs -Recurse -Force -ErrorAction SilentlyContinue
+          } else {
+            Write-Host "No log directory at $logs"
+          }
+          Write-Host 'Collected log files:'
+          Get-ChildItem editor-logs -Recurse -File -ErrorAction SilentlyContinue |
+            ForEach-Object { $_.FullName }
 
       - name: Upload editor logs on failure
         if: failure()
@@ -288,6 +300,7 @@ jobs:
           name: smoke-test-editor-logs-${{ matrix.example }}-windows
           path: editor-logs/**
           if-no-files-found: warn
+          retention-days: 7
 
       - name: Upload screenshots on failure
         if: failure()

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -144,6 +144,28 @@ jobs:
           WSO2IPW_ELECTRON_ARGS: ${{ matrix.example == 'icp' && '--no-sandbox --password-store=basic' || '--no-sandbox' }}
         run: bash "$(npm root -g)/wso2ipw/examples/${{ matrix.example }}/run-all.sh"
 
+      - name: Collect editor logs on failure
+        if: failure()
+        run: |
+          set +e
+          mkdir -p editor-logs
+          # code-oss writes per-session logs (main.log, exthost.log, per-extension output) under
+          # its user-data-dir. We don't know the exact dir wso2ipw uses, so search likely roots.
+          for root in "$HOME/.wso2ipw" "$HOME/.config" "$HOME/.wso2-integrator" "$HOME/.vscode-oss"; do
+            [ -d "$root" ] || continue
+            find "$root" -type f \( -name "*.log" -o -name "*.err" \) 2>/dev/null \
+              -exec cp --parents {} editor-logs/ \; 2>/dev/null
+          done
+          echo "Collected log files:"; find editor-logs -type f 2>/dev/null || true
+
+      - name: Upload editor logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-test-editor-logs-${{ matrix.example }}-linux
+          path: editor-logs/**
+          if-no-files-found: warn
+
       - name: Upload logs on failure
         if: failure()
         uses: actions/upload-artifact@v4
@@ -243,6 +265,29 @@ jobs:
       - name: Run ${{ matrix.example }}
         shell: bash
         run: bash "$(npm root -g)/wso2ipw/examples/${{ matrix.example }}/run-all.sh"
+
+      - name: Collect editor logs on failure
+        if: failure()
+        shell: bash
+        run: |
+          set +e
+          mkdir -p editor-logs
+          # code-oss writes per-session logs (main.log, exthost.log, per-extension output) under
+          # its user-data-dir. We don't know the exact dir wso2ipw uses, so search likely roots.
+          for root in "$USERPROFILE/.wso2ipw" "$APPDATA" "$USERPROFILE/.wso2-integrator"; do
+            [ -d "$root" ] || continue
+            find "$root" -type f \( -name "*.log" -o -name "*.err" \) 2>/dev/null \
+              -exec cp --parents {} editor-logs/ \; 2>/dev/null
+          done
+          echo "Collected log files:"; find editor-logs -type f 2>/dev/null || true
+
+      - name: Upload editor logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-test-editor-logs-${{ matrix.example }}-windows
+          path: editor-logs/**
+          if-no-files-found: warn
 
       - name: Upload screenshots on failure
         if: failure()


### PR DESCRIPTION
## Purpose

Getting the daily/release pipeline green landed a mix of changes on `dailyBuild` (#1921): source-level
patches, GitHub Actions tuning, and a full restructure of how versions are derived. #1939 extracted the
source-level patches and has merged. **This PR extracts only the workflow changes needed to make the
*current* pipeline pass** — nothing that changes how the build is driven or versioned.

The concrete failures it addresses:

1. A fully cold-cache `compile` job exceeds its 45-minute timeout.
2. `define-class-fields-check` and `tsec-compile-check` are OOM-killed when run concurrently, surfacing
   as a bare `exit 137` with no useful log.
3. The Choreo CLI download in **Build WI extension** hits `HTTP 403: rate limit exceeded`
   intermittently.
4. Any patch or `wi/**` edit busts the built-in extensions cache key outright, so the whole extensions
   directory is re-downloaded from scratch.
5. A failing smoke test produces nothing from the editor itself, so a crash inside code-oss is not
   diagnosable from the run.

## Goals

Repair the pipeline **without changing its interface.** No workflow input is added, removed, renamed or
retyped, and no workflow is renamed. `build-and-release.yml` keeps its name and its full
`workflow_dispatch` form, `delivery_mode` included — anyone dispatching a build after this merges sees
exactly the form they see today.

Everything that changes the *shape* of the pipeline — `workflow_call`, version stamping, the nightly —
is deliberately excluded and lives in the versioning/nightly follow-up (branch
`ci/versioning-and-nightly`, not yet raised).

`dailyBuild` is unchanged; this is an extraction for review.

## Approach

**5 commits, 3 files, +144/−3.** All five items are independent; any one can be dropped.

### 1. Cold-build timeout — `compile.yml`

`timeout-minutes: 45` → `90` on the `compile` job.

The failure mode is worse than a slow build: the timeout cancels the job *before* the `actions/cache`
post-step that **saves** the caches runs, so the next run starts cold too, times out, and saves nothing
again. Once a cold run appears the pipeline cannot recover on its own. Warm runs finish well under 90;
this only raises the ceiling for the cold case.

**Cost:** a genuinely hung job now burns 90 runner-minutes instead of 45.

### 2. Validation checks grouped by memory cap — `compile.yml`

`patches/increaseHeap.diff` caps the node heap on three of the five checks: `tsec-compile-check` at
8192 MB, `define-class-fields-check` at 4096 then 8192, and `valid-layers-check` at 4096. Two capped
checks running concurrently exceed the runner and the kernel OOM-kills one.

So the three capped checks run serially and only the two uncapped ones run in parallel, in **both** the
cache-hit and cache-miss branches of the compile step:

```bash
npm exec -- npm-run-all -lp eslint vscode-dts-compile-check
npm exec -- npm-run-all -ls valid-layers-check define-class-fields-check tsec-compile-check
```

Both branches are changed because the cache-hit path runs the same five checks; leaving it parallel
would reintroduce the OOM as soon as the TypeScript cache is enabled.

**Cost:** slower than running all five together. It is the reason item 1 is in the same PR. Grouping by
heap cap rather than serialising all five recovers most of the parallelism; `valid-layers-check` is on
the serial side because its 4 GB cap makes it the check most likely to push a parallel group over the
limit.

### 3. Authenticated Choreo CLI download — `compile.yml`

Adds `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to the **Build WI extension** step.

`wi/wi-extension/scripts/download-choreo-cli.js` fetches Choreo CLI binaries from the GitHub API.
Unauthenticated, those calls share the 60 requests/hour per-IP limit; a token raises it to 5000/hour.
Every other GitHub-API step in this job already passes the token — this one was simply missed.

### 4. Built-in extensions cache fallback — `compile.yml`, `build-and-release.yml`

Adds a `restore-keys:` prefix to the `extensions-shared-*` cache in `compile.yml` and in
`build-and-release.yml`'s `build-macos` and `build-windows` jobs:

```yaml
restore-keys: |
  extensions-shared-<bal-source>-<bal-version>-<mi-source>-<mi-version>-
```

The exact key includes `hashFiles('patches/*.diff', …, 'wi/**')`, so any patch or WI source change
makes it miss. The prefix is that key minus the hash, which is precisely the churn being absorbed, so
the previous directory is restored and `download-builtin-extensions` re-fetches only what actually
changed.

**What the fallback holds fixed is not uniform, and that is worth stating rather than glossing.** Of the
six extensions in `product.json`'s `builtInExtensions`, only two — Ballerina and MI — have their own key
fields, because they are the two with a marketplace-vs-vsix source switch and the version came along
with the switch. The `streaming-integrator`, `hurl-client` and `mcp-server-inspector` versions live
*only* inside the dropped hash, so a fallback can cross those, as it can WI's. That is safe for the
three marketplace extensions because `isUpToDate` compares version strings and theirs move when their
contents do. WI is the one it cannot catch, which is what the removal above exists for.

Also worth recording: pinning Ballerina and MI in the prefix is *not* the most cache-efficient choice
available. Leaving them out would let a fallback cross those upgrades too, and `isUpToDate` would
re-fetch just the upgraded component while everything else stayed warm — strictly more reuse. They are
pinned anyway because a fallback that crosses a version is harder to reason about than the cache it
saves is worth, and because a bump is a cold extensions cache on `main` today, so nothing regresses.

**This is the item that needed the most care, and it carries a fix for a defect it would otherwise
introduce.** A prefix-restored hit means `cache-hit` is `false`, so `download-builtin-extensions` runs
and decides per extension via `isUpToDate()` in `lib/vscode/build/lib/builtInExtensions.ts:53` — which
compares **only the version string** on disk against `product.json`. `syncMarketplaceExtension()`
returns early on that check, before it would `rimraf` and re-unpack.

`wso2.wso2-integrator` is exactly such a pin. `ci/build/update-product.sh:60` reads its version from
`wi/wi-extension/package.json` (`1.0.1`, hand-bumped) and writes it into `product.json` at `:174-178`.
That string does not move when `wi/**` content changes — but a `wi/**` change is what busts the exact
key. So without a fix, editing `wi/**` could restore a stale WI extension, have `isUpToDate` judge it
current, and ship it: green build, wrong artifact, no log line saying so.

The fix is to remove that one extension directory on the cache-miss path, in all three places
`download-builtin-extensions` runs:

```bash
rm -rf .build/builtInExtensions/wso2.wso2-integrator
npm run download-builtin-extensions
```

The exact-hit path needs nothing — that key hashes `wi/**`, so an exact hit means identical WI content
by construction. Components whose version strings do move (Ballerina, MI) are already caught by
`isUpToDate`. On the macOS and Windows jobs the vsix is present when the re-unpack happens: **Download
WI extension VSIX** runs at `build-and-release.yml:240`/`:596`, well before **Install builtin
extensions** at `:312`/`:699`.

Credit to @NipunaRanasinghe for catching this — an earlier revision of this description asserted no such
pin existed, which was wrong.

### 5. Smoke-test failure diagnostics — `smoke-test.yml`

Adds **Collect editor logs on failure** / **Upload editor logs on failure** to the Linux and Windows
matrix jobs.

The log directory is derived, not guessed: `lib/vscode/src/main.ts:57` passes `product.nameShort` into
`getUserDataPath()`, and `getDefaultUserDataPath()` joins it onto `$XDG_CONFIG_HOME`/`~/.config` on
Linux and `$APPDATA` on Windows. `nameShort` is `WSO2 Integrator`
(`ci/build/update-product.sh:69`), so the collectors copy exactly `<user-data-dir>/logs` and nothing
else — no unrelated tooling logs can reach the artifact. Uploads carry `retention-days: 7`.

The Windows collector runs in `pwsh`, matching the other native steps in that job. It previously ran
under Git Bash while reading `$APPDATA`, which holds a backslashed Windows path — so every candidate
root failed its `[ -d … ]` test, nothing was copied, and `if-no-files-found: warn` hid it. It was a
silent no-op on every failed Windows run.

Diagnostics only, and cannot affect a run's result: `if: failure()`, `set +e` / `-ErrorAction
SilentlyContinue`, and `if-no-files-found: warn`.

**Known limitation, stated rather than papered over:** the path is code-oss's *default* resolution. If
`wso2ipw` launches the editor with an explicit `--user-data-dir`, the real path differs and the
collectors find nothing. `wso2ipw` is a published npm package, not vendored here, so this could not be
confirmed by reading the repo. `if-no-files-found: warn` on a failing run is the signal that the
assumption needs revisiting.

## User stories

N/A — CI/build infrastructure only. No user-facing behaviour changes.

## Release note

N/A — no product change ships from this PR. It only affects how the product is built and tested.

## Documentation

N/A — no user-facing or configuration change. The reasoning behind each workaround is recorded as
comments at each site, since these are runner-constraint workarounds that will otherwise look arbitrary
to the next reader.

## Training

N/A — no product functionality change.

## Certification

N/A — no product functionality change, so no impact on certification exams.

## Marketing

N/A — internal build infrastructure.

## Automation tests

- **Unit tests** — N/A. No product code is touched; the three changed files are GitHub Actions
  workflows, which have no unit-test harness in this repo.
- **Integration tests** — item 5 exists to make the *existing* smoke tests diagnosable when they fail;
  it adds no new test cases.

What was verified locally:

- All three workflow files parse as YAML. Structurally confirmed via the parsed YAML that each of the
  three cache blocks carries exactly one `restore-keys` entry, and that the WI removal sits inside the
  `else` (cache-miss) branch in all three jobs, never on the exact-hit path.
- The WI staleness defect and its fix were reproduced by executing the shipped `isUpToDate` /
  `getExtensionPath` function bodies verbatim against fixtures: with a same-version directory on disk it
  returns `true` (skip — fresh vsix never unpacked); after the `rm -rf` it returns `false` (unpack); and
  a component whose version string moved returns `false` without needing any fix.
- The Linux log collector was dry-run against a fabricated tree seeded with decoy files under
  `~/.config` (including a fake credential file); only the product's own `logs/` tree was collected. The
  missing-directory case prints its reason and exits 0.

What was **not** verified — **no pipeline run has been done against this branch.** The claims about the
90-minute ceiling, the OOM disappearing, and the prefix cache hit are reasoned from the failure logs on
#1921, not re-demonstrated here. Two things specifically need a real run:

- **Item 2's grouping is the highest-risk part of this PR.** It reintroduces parallelism, and if the
  grouping is still too wide the symptom is a bare `exit 137` after a ~90-minute cold job. Widening or
  narrowing it is a one-line change.
- **The Windows log collector has never once worked**, so it cannot be proven without a *failing*
  Windows smoke test. `pwsh` is not available on the machine used to prepare this, so that step is
  inspection-verified only.

Suggested first run: dispatch `build-and-release.yml` from this branch with the inputs used today —
expect `compile` inside 90 minutes on a cold cache, no `exit 137`, no Choreo 403, and an
`extensions-shared-…` restore-key hit visible on a second run.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
  **yes** — the only new code is shell/PowerShell in workflow steps. Notably, item 5's collectors target
  one derived directory rather than sweeping user directories, so unrelated credentials cannot be picked
  up into an artifact; and the added `GITHUB_TOKEN` uses the per-run `secrets.GITHUB_TOKEN` rather than
  a long-lived PAT.
- Ran FindSecurityBugs plugin and verified report? **N/A** — no Java source is touched.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
  **yes** — the only credential reference is `${{ secrets.GITHUB_TOKEN }}`, resolved at run time.

## Samples

N/A — no feature to sample.

## Related PRs

- **#1939** (`extract/pipeline-unblock-patches`) — the source-level `patches/*.diff` half of the same
  split. **Merged**; this branch is rebased onto it, so this diff is now exactly the 3 workflow files.
- **Follow-up, not yet raised** — `ci/versioning-and-nightly`: `workflow_call`, version stamping and the
  nightly. It is stacked on this branch. Relevant here: its rolling-tag Ballerina pin is a *second*
  instance of the `isUpToDate` class of bug fixed in item 4, and it must carry an equivalent fix.
- **#1921** (`dailyBuild`) — the original combined branch these three PRs were extracted from.

Separately, CodeRabbit flagged a genuine issue in `patches/gettingStarted.diff` — `createSession`
fabricating a token via `Math.random()` and accepting a hard-coded email. That code is pre-existing on
`main` and is no longer in this diff post-rebase; it is being filed as its own security issue rather
than handled here.

## Migrations (if applicable)

N/A — no data or configuration migration. One operational note: the first run after merge will not get
an `extensions-shared-…` prefix hit, because no cache entry exists under the new key shape yet. The
second run onward will.

## Test environment

Not applicable in the usual sense — no product build was produced or exercised. The changes were
validated by static and functional inspection on macOS 15 (Darwin 25.5.0) with Node.js from the repo's
toolchain; `pwsh` was unavailable there, so the Windows collector was inspection-verified only.

The workflows target the environments they already targeted: `ubuntu-latest` (or the configured AWS
runner) for `compile`, `macos-*` for `build-macos`, `windows-2022` for `build-windows`.

## Learning

The useful finding was that the "safe because it re-validates" reasoning behind cache `restore-keys` is
only as strong as the validation it leans on. `isUpToDate()` compares version strings, which is
sufficient for components whose versions move with their contents and silently wrong for anything
pinned to a constant. That made the WI extension — the one component built in-tree, and so the one most
likely to change without a version bump — the exact case the check cannot catch. Worth remembering that
a prefix cache hit is not a weaker version of an exact hit; it changes which code decides correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved built-in extension cache partial restore logic on both macOS and Windows to better reuse the correct cached extension set during cold builds.
  * On cache misses, forced a clean re-unpack for the pinned WI extension before downloading built-in extensions.
  * Increased the compile job timeout to reduce cold-cache cancellations.
  * Split TypeScript validation into separate lint/DTS phases and ran heavier checks serially; improved authenticated extension downloads.
* **Diagnostics**
  * Enhanced smoke-test failure handling by collecting editor logs on Linux and Windows and uploading them as new artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->