### PR TITLE
fix(wi): authenticate the webview websocket bridge and allowlist runCommand

### DIFF
--- a/patches/gettingStarted.diff
+++ b/patches/gettingStarted.diff
@@ -247,7 +247,7 @@ Index: product-integrator/lib/vscode/src/vs/workbench/browser/parts/editor/wso2E
 ===================================================================
 --- /dev/null
 +++ product-integrator/lib/vscode/src/vs/workbench/browser/parts/editor/wso2EditorGroupWatermark.ts
-@@ -0,0 +1,667 @@
+@@ -0,0 +1,691 @@
 +/*---------------------------------------------------------------------------------------------
 + *  Copyright (c) Microsoft Corporation. All rights reserved.
 + *  Licensed under the MIT License. See License.txt in the project root for license information.
@@ -264,7 +264,8 @@ Index: product-integrator/lib/vscode/src/vs/workbench/browser/parts/editor/wso2E
 +// eslint-disable-next-line local/code-import-patterns
 +import { IWebviewElement, IWebviewService } from '../../../contrib/webview/browser/webview.js';
 +// eslint-disable-next-line local/code-import-patterns
-+import { asWebviewUri } from '../../../contrib/webview/common/webview.js';
++import { asWebviewUri, webviewRootResourceAuthority } from '../../../contrib/webview/common/webview.js';
++import { generateUuid } from '../../../../base/common/uuid.js';
 +// eslint-disable-next-line local/code-import-patterns
 +import { WebviewThemeDataProvider } from '../../../contrib/webview/browser/themeing.js';
 +import { IExtensionService } from '../../../services/extensions/common/extensions.js';
@@ -275,6 +276,12 @@ Index: product-integrator/lib/vscode/src/vs/workbench/browser/parts/editor/wso2E
 +	mode: 'proxy' | 'websocket';
 +	wsServer: string;
 +	wsPort: number;
++	/**
++	 * Token the webview presents on the bridge websocket handshake. The extension
++	 * refuses upgrades without it, so this must survive into the injected
++	 * bootstrap or the embedded view cannot connect.
++	 */
++	wsToken?: string;
 +}
 +
 +interface IEmbeddedWelcomeThemeData {
@@ -612,10 +619,27 @@ Index: product-integrator/lib/vscode/src/vs/workbench/browser/parts/editor/wso2E
 +		const serializedBootstrap = JSON.stringify(bootstrap).replace(/</g, '\\u003c');
 +		const serializedThemeData = JSON.stringify(themeData).replace(/</g, '\\u003c');
 +
++		// Mirrors the policy the WSO2 Integrator extension applies to this same
++		// bundle when it hosts it in an extension webview. Inline scripts are
++		// authorized by a per-render nonce; `connect-src` allows the loopback
++		// bridge socket this view talks to, and `img-src https:` covers the
++		// remotely hosted sample icons the welcome page renders.
++		const nonce = generateUuid();
++		const cspSource = `https://*.${webviewRootResourceAuthority}`;
++		const csp = [
++			`default-src 'none'`,
++			`script-src 'nonce-${nonce}' ${cspSource}`,
++			`style-src ${cspSource} 'unsafe-inline'`,
++			`font-src ${cspSource} data:`,
++			`img-src ${cspSource} data: https:`,
++			`connect-src ${cspSource} ws://127.0.0.1:*`
++		].join('; ');
++
 +		return `<!DOCTYPE html>
 +				<html lang="en">
 +					<head>
 +						<meta charset="utf-8">
++						<meta http-equiv="Content-Security-Policy" content="${csp}">
 +						<meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">
 +					<title>WSO2 Integrator</title>
 +					<style>
@@ -741,7 +765,7 @@ Index: product-integrator/lib/vscode/src/vs/workbench/browser/parts/editor/wso2E
 +					</style>
 +				</head>
 +				<body>
-+					<script>
++					<script nonce="${nonce}">
 +						(function () {
 +							var themeData = ${serializedThemeData};
 +							var rootStyle = document.documentElement.style;
@@ -777,7 +801,7 @@ Index: product-integrator/lib/vscode/src/vs/workbench/browser/parts/editor/wso2E
 +						<div class="embedded-welcome-loader-text">Loading WSO2 Integrator...</div>
 +					</div>
 +					<div id="root"></div>
-+					<script>
++					<script nonce="${nonce}">
 +						window.__WI_BRIDGE_BOOTSTRAP = ${serializedBootstrap};
 +						window.__WI_EMBEDDED_WELCOME_HIDE_LOADER = function () {
 +							document.body.classList.add('embedded-welcome-ready');
@@ -796,7 +820,7 @@ Index: product-integrator/lib/vscode/src/vs/workbench/browser/parts/editor/wso2E
 +							}
 +						});
 +					</script>
-+					<script defer src=${JSON.stringify(scriptUri)}></script>
++					<script defer nonce="${nonce}" src=${JSON.stringify(scriptUri)}></script>
 +					</body>
 +				</html>`;
 +	}

--- a/wi/wi-core/src/types/network-bridge.types.ts
+++ b/wi/wi-core/src/types/network-bridge.types.ts
@@ -271,4 +271,10 @@ export interface WITransportBootstrap {
     mode: WITransportMode;
     wsServer: string;
     wsPort: number;
+    /**
+     * Token the webview must present when opening the websocket connection.
+     * The extension rejects websocket upgrades that do not carry a matching
+     * token, so a client that merely reaches the port cannot drive the bridge.
+     */
+    wsToken?: string;
 }

--- a/wi/wi-core/src/types/network-bridge.types.ts
+++ b/wi/wi-core/src/types/network-bridge.types.ts
@@ -271,10 +271,6 @@ export interface WITransportBootstrap {
     mode: WITransportMode;
     wsServer: string;
     wsPort: number;
-    /**
-     * Token the webview must present when opening the websocket connection.
-     * The extension rejects websocket upgrades that do not carry a matching
-     * token, so a client that merely reaches the port cannot drive the bridge.
-     */
+    /** Token the webview presents when opening the websocket connection. */
     wsToken?: string;
 }

--- a/wi/wi-extension/src/BridgeLayer.ts
+++ b/wi/wi-extension/src/BridgeLayer.ts
@@ -17,6 +17,7 @@
  */
 
 import { WebviewPanel } from "vscode";
+import { randomBytes } from "crypto";
 import { createExtensionTransportManager, createRequestRouter } from "@wso2/webview-giga-bridge";
 import {
     BIProjectRequest,
@@ -173,6 +174,11 @@ export class BridgeLayer {
         const transport = createExtensionTransportManager<WIBridgeRequest, WIBridgeResponse>({
             initialMode: "proxy",
             wsPort: this.resolveWebSocketPort(),
+            // Per-channel secret. The bridge rejects websocket upgrades that do
+            // not present it, so reaching the port is not enough to issue
+            // requests or receive broadcast events. Proxy mode is unaffected --
+            // it runs in-process over the trusted webview postMessage channel.
+            authToken: randomBytes(32).toString("hex"),
             handleRequest: (request) => router.handle(request),
         });
 

--- a/wi/wi-extension/src/BridgeLayer.ts
+++ b/wi/wi-extension/src/BridgeLayer.ts
@@ -87,11 +87,8 @@ export class BridgeLayer {
     }
 
     /**
-     * Starts the websocket backend and returns its connection coordinates.
-     *
-     * Awaiting the start is required: the port is only known once the server is
-     * bound, so `getWebviewBootstrap()` would otherwise report the configured
-     * `wsPort` (0 when the OS allocates one).
+     * Starts the websocket backend and returns its connection coordinates. The
+     * start must be awaited: the port is only known once the server is bound.
      */
     static async startWebSocketServer(projectUri: string): Promise<WITransportBootstrap> {
         const channel = this.getOrCreateChannel(projectUri);
@@ -181,10 +178,8 @@ export class BridgeLayer {
         const transport = createExtensionTransportManager<WIBridgeRequest, WIBridgeResponse>({
             initialMode: "proxy",
             wsPort: this.resolveWebSocketPort(),
-            // Per-channel secret. The bridge rejects websocket upgrades that do
-            // not present it, so reaching the port is not enough to issue
-            // requests or receive broadcast events. Proxy mode is unaffected --
-            // it runs in-process over the trusted webview postMessage channel.
+            // Per-channel secret authenticating the websocket handshake. Unused
+            // by proxy mode, which runs in-process over postMessage.
             authToken: randomBytes(32).toString("hex"),
             handleRequest: (request) => router.handle(request),
         });

--- a/wi/wi-extension/src/BridgeLayer.ts
+++ b/wi/wi-extension/src/BridgeLayer.ts
@@ -86,12 +86,19 @@ export class BridgeLayer {
         return this.getOrCreateChannel(projectUri).transport.getWebviewBootstrap();
     }
 
-    static startWebSocketServer(projectUri: string): WITransportBootstrap {
+    /**
+     * Starts the websocket backend and returns its connection coordinates.
+     *
+     * Awaiting the start is required: the port is only known once the server is
+     * bound, so `getWebviewBootstrap()` would otherwise report the configured
+     * `wsPort` (0 when the OS allocates one).
+     */
+    static async startWebSocketServer(projectUri: string): Promise<WITransportBootstrap> {
         const channel = this.getOrCreateChannel(projectUri);
         if (channel.transport.getMode() !== "websocket") {
-            channel.transport.switchMode("websocket");
+            await channel.transport.switchMode("websocket");
         } else if (!channel.transport.isWebSocketServerRunning()) {
-            channel.transport.startWebSocketServer();
+            await channel.transport.startWebSocketServer();
         }
         return channel.transport.getWebviewBootstrap();
     }

--- a/wi/wi-extension/src/extension.ts
+++ b/wi/wi-extension/src/extension.ts
@@ -88,7 +88,7 @@ function registerEmbeddedWelcomeBootstrapCommand(context: vscode.ExtensionContex
 		vscode.commands.registerCommand(GET_EMBEDDED_WELCOME_BOOTSTRAP_COMMAND, async () => {
 			StateMachine.setCurrentView(ViewType.WELCOME);
 
-			const bootstrap = BridgeLayer.startWebSocketServer(EMBEDDED_WELCOME_PROJECT_URI);
+			const bootstrap = await BridgeLayer.startWebSocketServer(EMBEDDED_WELCOME_PROJECT_URI);
 			BridgeLayer.notifyStateChanged(EMBEDDED_WELCOME_PROJECT_URI, {
 				currentView: ViewType.WELCOME,
 				projectUri: EMBEDDED_WELCOME_PROJECT_URI,

--- a/wi/wi-extension/src/stateMachine.ts
+++ b/wi/wi-extension/src/stateMachine.ts
@@ -278,7 +278,7 @@ const stateMachine = createMachine<MachineContext>({
                 });
             }
             vscode.commands.executeCommand('setContext', 'WI.projectType', 'none');
-            void context.webviewManager.showWelcome();
+            void context.webviewManager.showWelcome().catch((error) => ext.logError("Failed to show welcome webview", error as Error));
             context.currentView = ViewType.WELCOME;
         },
         registerConfigChangeListener: (context) => {
@@ -477,7 +477,7 @@ export const StateMachine = {
         // Get the webview manager from context and show the view
         const context = stateService.getSnapshot().context;
         if (context.webviewManager) {
-            void context.webviewManager.show(view);
+            void context.webviewManager.show(view).catch((error) => ext.logError("Failed to show webview", error as Error));
         } else {
             ext.log('WebviewManager not available in state machine context');
         }

--- a/wi/wi-extension/src/stateMachine.ts
+++ b/wi/wi-extension/src/stateMachine.ts
@@ -278,7 +278,7 @@ const stateMachine = createMachine<MachineContext>({
                 });
             }
             vscode.commands.executeCommand('setContext', 'WI.projectType', 'none');
-            context.webviewManager.showWelcome();
+            void context.webviewManager.showWelcome();
             context.currentView = ViewType.WELCOME;
         },
         registerConfigChangeListener: (context) => {
@@ -477,7 +477,7 @@ export const StateMachine = {
         // Get the webview manager from context and show the view
         const context = stateService.getSnapshot().context;
         if (context.webviewManager) {
-            context.webviewManager.show(view);
+            void context.webviewManager.show(view);
         } else {
             ext.log('WebviewManager not available in state machine context');
         }

--- a/wi/wi-extension/src/webviewManager.ts
+++ b/wi/wi-extension/src/webviewManager.ts
@@ -117,17 +117,21 @@ export class WebviewManager {
 
 	constructor(private projectUri: string) {
 		if (process.env.WEB_VIEW_DEV_MODE === "true") {
-			try {
-				const bootstrap = BridgeLayer.startWebSocketServer(projectUri);
-				vscode.window.showInformationMessage(
-					`Webview bridge server started on ws://${bootstrap.wsServer}:${bootstrap.wsPort}`,
-				);
-			} catch (error) {
-				ext.logError("Failed to start bridge server", error as Error);
-				vscode.window.showErrorMessage(
-					`Failed to start bridge server: ${error instanceof Error ? error.message : String(error)}`,
-				);
-			}
+			// The port is only known once the server is bound, and a constructor
+			// cannot await, so report the outcome when the start settles.
+			void BridgeLayer.startWebSocketServer(projectUri).then(
+				(bootstrap) => {
+					vscode.window.showInformationMessage(
+						`Webview bridge server started on ws://${bootstrap.wsServer}:${bootstrap.wsPort}`,
+					);
+				},
+				(error: unknown) => {
+					ext.logError("Failed to start bridge server", error as Error);
+					vscode.window.showErrorMessage(
+						`Failed to start bridge server: ${error instanceof Error ? error.message : String(error)}`,
+					);
+				},
+			);
 		}
 	}
 

--- a/wi/wi-extension/src/webviewManager.ts
+++ b/wi/wi-extension/src/webviewManager.ts
@@ -114,12 +114,14 @@ export class WebviewManager {
 	private currentPanel: vscode.WebviewPanel | undefined;
 	private currentViewType: ViewType | undefined;
 	private stateSubscription: any;
+	/** Resolves once the dev-mode bridge server is bound. */
+	private bridgeReady: Promise<void> = Promise.resolve();
 
 	constructor(private projectUri: string) {
 		if (process.env.WEB_VIEW_DEV_MODE === "true") {
-			// The port is only known once the server is bound, and a constructor
-			// cannot await, so report the outcome when the start settles.
-			void BridgeLayer.startWebSocketServer(projectUri).then(
+			// A constructor cannot await, so keep the startup so `show()` can wait
+			// for the port before embedding it in the webview HTML.
+			this.bridgeReady = BridgeLayer.startWebSocketServer(projectUri).then(
 				(bootstrap) => {
 					vscode.window.showInformationMessage(
 						`Webview bridge server started on ws://${bootstrap.wsServer}:${bootstrap.wsPort}`,
@@ -138,7 +140,11 @@ export class WebviewManager {
 	/**
 	 * Show webview with specified type
 	 */
-	public show(viewType: ViewType = ViewType.WELCOME): void {
+	public async show(viewType: ViewType = ViewType.WELCOME): Promise<void> {
+		// The webview HTML embeds the bridge coordinates, and the dev-mode server
+		// is assigned its port asynchronously, so wait before rendering.
+		await this.bridgeReady;
+
 		const columnToShowIn = vscode.window.activeTextEditor
 			? vscode.window.activeTextEditor.viewColumn
 			: undefined;
@@ -225,8 +231,8 @@ export class WebviewManager {
 	/**
 	 * Show welcome webview
 	 */
-	public showWelcome(): void {
-		this.show(ViewType.WELCOME);
+	public showWelcome(): Promise<void> {
+		return this.show(ViewType.WELCOME);
 	}
 
 	public closeWebview(): void {

--- a/wi/wi-extension/src/ws-managers/main/ws-manager.ts
+++ b/wi/wi-extension/src/ws-managers/main/ws-manager.ts
@@ -69,9 +69,8 @@ const SAMPLES_INFO_URL = process.env.SAMPLES_INFO_URL;
 const PREBUILT_INTEGRATIONS_URL = process.env.PREBUILT_INTEGRATIONS_URL;
 
 /**
- * Command ids the webview is permitted to invoke through the `runCommand`
- * route. Keep this in sync with the `wsClient.runCommand` call sites in
- * `wi-webviews`; anything absent here is refused.
+ * Command ids the webview may invoke via `runCommand`; anything else is refused.
+ * Keep in sync with the `wsClient.runCommand` call sites in `wi-webviews`.
  */
 const ALLOWED_WEBVIEW_COMMANDS: ReadonlySet<string> = new Set([
     // Cloud auth / project flows
@@ -162,9 +161,8 @@ export class MainWsManager implements WIVisualizerAPI {
 
     async runCommand(props: RunCommandRequest): Promise<RunCommandResponse> {
         if (!ALLOWED_WEBVIEW_COMMANDS.has(props.command)) {
-            // Forwarding an arbitrary command id would turn this route into a
-            // general-purpose command-execution primitive for anything that can
-            // talk to the bridge, so unknown ids are refused rather than run.
+            // Forwarding arbitrary ids would make this a general command-execution
+            // primitive for anything that can reach the bridge.
             ext.logError(`Blocked disallowed webview command: ${props.command}`);
             return { success: false, error: `Command not allowed: ${props.command}` };
         }

--- a/wi/wi-extension/src/ws-managers/main/ws-manager.ts
+++ b/wi/wi-extension/src/ws-managers/main/ws-manager.ts
@@ -51,6 +51,7 @@ import {
     BIRuntimeStatusResponse,
     EXTENSION_DEPENDENCIES,
 } from "@wso2/wi-core";
+import { WICommandIds } from "@wso2/wso2-platform-core";
 import { commands, extensions, window, workspace, MarkdownString, Uri, env, ConfigurationTarget } from "vscode";
 import { getActiveBallerinaExtension } from "../../utils/ballerinaExtension";
 import { getDefaultCreationPath } from "../../utils/pathUtils";
@@ -66,6 +67,26 @@ import { ballerinaContext } from "../../bi/ballerinaContext";
 const platform = getPlatform();
 const SAMPLES_INFO_URL = process.env.SAMPLES_INFO_URL;
 const PREBUILT_INTEGRATIONS_URL = process.env.PREBUILT_INTEGRATIONS_URL;
+
+/**
+ * Command ids the webview is permitted to invoke through the `runCommand`
+ * route. Keep this in sync with the `wsClient.runCommand` call sites in
+ * `wi-webviews`; anything absent here is refused.
+ */
+const ALLOWED_WEBVIEW_COMMANDS: ReadonlySet<string> = new Set([
+    // Cloud auth / project flows
+    WICommandIds.SignIn,
+    WICommandIds.SignOut,
+    WICommandIds.CancelSignIn,
+    WICommandIds.CloneProject,
+    // Runtime setup
+    "ballerina.setup-ballerina",
+    // VS Code workbench actions used by the welcome and component form views
+    "workbench.action.openRecent",
+    "workbench.action.reloadWindow",
+    "workbench.scm.focus",
+    "git.push",
+]);
 
 export class MainWsManager implements WIVisualizerAPI {
     constructor(private projectUri?: string) { }
@@ -140,6 +161,14 @@ export class MainWsManager implements WIVisualizerAPI {
     }
 
     async runCommand(props: RunCommandRequest): Promise<RunCommandResponse> {
+        if (!ALLOWED_WEBVIEW_COMMANDS.has(props.command)) {
+            // Forwarding an arbitrary command id would turn this route into a
+            // general-purpose command-execution primitive for anything that can
+            // talk to the bridge, so unknown ids are refused rather than run.
+            ext.logError(`Blocked disallowed webview command: ${props.command}`);
+            return { success: false, error: `Command not allowed: ${props.command}` };
+        }
+
         return await commands.executeCommand(props.command, ...(props.args || []));
     }
 

--- a/wi/wi-extension/src/ws-managers/main/ws-manager.ts
+++ b/wi/wi-extension/src/ws-managers/main/ws-manager.ts
@@ -71,6 +71,9 @@ const PREBUILT_INTEGRATIONS_URL = process.env.PREBUILT_INTEGRATIONS_URL;
 /**
  * Command ids the webview may invoke via `runCommand`; anything else is refused.
  * Keep in sync with the `wsClient.runCommand` call sites in `wi-webviews`.
+ *
+ * Note this gates ids only — `args` are forwarded to the command as given, so a
+ * compromised webview still controls the payloads of the commands listed here.
  */
 const ALLOWED_WEBVIEW_COMMANDS: ReadonlySet<string> = new Set([
     // Cloud auth / project flows
@@ -162,9 +165,11 @@ export class MainWsManager implements WIVisualizerAPI {
     async runCommand(props: RunCommandRequest): Promise<RunCommandResponse> {
         if (!ALLOWED_WEBVIEW_COMMANDS.has(props.command)) {
             // Forwarding arbitrary ids would make this a general command-execution
-            // primitive for anything that can reach the bridge.
+            // primitive for anything that can reach the bridge. Throw rather than
+            // return a failed response: callers cannot detect the latter, since the
+            // success path resolves with whatever the command returned.
             ext.logError(`Blocked disallowed webview command: ${props.command}`);
-            return { success: false, error: `Command not allowed: ${props.command}` };
+            throw new Error(`Command not allowed: ${props.command}`);
         }
 
         return await commands.executeCommand(props.command, ...(props.args || []));

--- a/wi/wi-webviews/src/network-bridge/WsClient.ts
+++ b/wi/wi-webviews/src/network-bridge/WsClient.ts
@@ -113,9 +113,7 @@ export function resolveBridgeBootstrap(): WITransportBootstrap {
         mode: explicitMode ?? (hasVsCodeApi ? "proxy" : "websocket"),
         wsServer: queryWsServer ?? runtimeBootstrap?.wsServer ?? "127.0.0.1",
         wsPort: resolvedWsPort,
-        // The extension injects the token via `window.__WI_BRIDGE_BOOTSTRAP`.
-        // The query-parameter form only exists for browser-based dev runs,
-        // where the token has to be supplied manually.
+        // Injected by the extension; the query parameter is for browser dev runs.
         wsToken: runtimeBootstrap?.wsToken ?? urlParams.get("wsToken") ?? undefined,
     };
 }

--- a/wi/wi-webviews/src/network-bridge/WsClient.ts
+++ b/wi/wi-webviews/src/network-bridge/WsClient.ts
@@ -113,6 +113,10 @@ export function resolveBridgeBootstrap(): WITransportBootstrap {
         mode: explicitMode ?? (hasVsCodeApi ? "proxy" : "websocket"),
         wsServer: queryWsServer ?? runtimeBootstrap?.wsServer ?? "127.0.0.1",
         wsPort: resolvedWsPort,
+        // The extension injects the token via `window.__WI_BRIDGE_BOOTSTRAP`.
+        // The query-parameter form only exists for browser-based dev runs,
+        // where the token has to be supplied manually.
+        wsToken: runtimeBootstrap?.wsToken ?? urlParams.get("wsToken") ?? undefined,
     };
 }
 
@@ -122,6 +126,7 @@ export class WsClient {
         mode: this.bootstrap.mode,
         server: this.bootstrap.wsServer,
         port: this.bootstrap.wsPort,
+        token: this.bootstrap.wsToken,
     });
     private readonly stateChangedListeners = new Set<(context: WebviewContext) => void>();
     private readonly downloadProgressListeners = new Set<(progress: DownloadProgress) => void>();


### PR DESCRIPTION
## Purpose

The embedded welcome page starts the giga-bridge websocket backend on activation (`BridgeLayer.startWebSocketServer`), but the transport manager was created **without an auth token**, and the `runCommand` route forwarded arbitrary command ids straight to `commands.executeCommand`.

Any client that could reach the port was therefore able to drive the extension — execute commands, read cloud credentials, clone repositories, write project files — and additionally received every broadcast event (`STATE_CHANGED`, `AUTH_STATE_CHANGED`, download/clone progress) simply by connecting and staying quiet.

The listening socket also bound to all interfaces, which is fixed in the companion library change (wso2/vscode-extensions#2435) that this PR picks up.

## Goals

1. Make reaching the port insufficient — connections must prove they are the intended webview.
2. Stop `runCommand` from being a general-purpose command-execution primitive, even for a caller that *is* authenticated.

## Approach

**1. Token-gated websocket (`BridgeLayer.ts`)** — the transport manager is created with a per-channel `authToken` (32 random bytes). The bridge validates it during the websocket handshake and rejects non-matching upgrades, so unauthenticated clients never connect and therefore cannot issue requests *or* observe broadcasts.

Proxy mode is deliberately left ungated: it runs in-process over the trusted webview `postMessage` channel and is not exposed on a port.

**2. Token delivery (`WITransportBootstrap`, `WsClient.ts`)** — the token travels to the webview as `wsToken` and is passed to the transport adapter, which sends it during the handshake. No new extension plumbing was required — `webviewManager` already serializes the whole bootstrap object into the page. The query-parameter form is kept only for browser-based dev runs.

**3. `runCommand` allowlist (`ws-managers/main/ws-manager.ts`)** — command ids outside `ALLOWED_WEBVIEW_COMMANDS` are refused and logged. The list was derived from the actual `wsClient.runCommand` call sites in `wi-webviews` (13 of them), not guessed:

| Source | Commands |
|---|---|
| `WICommandIds` | `SignIn`, `SignOut`, `CancelSignIn`, `CloneProject` |
| Runtime setup | `ballerina.setup-ballerina` |
| Workbench | `workbench.action.openRecent`, `workbench.action.reloadWindow`, `workbench.scm.focus`, `git.push` |

This layer matters because it still holds if the webview itself is compromised (e.g. XSS in welcome content) — a transport token cannot defend against that.

**Note on design:** authentication is enforced at the **handshake**, not per request. That is why no token field was added to `WIBridgeRequest` — rejected clients never open a connection, which also closes the broadcast-observation path that a per-request check would leave open.

## Submodule bump

Includes `external/wso2-vscode-extensions`: `fae80157d` → `be1a5b98a`. This is **required**, not incidental — the `authToken` / `token` / `wsToken` options do not exist at the previous pin, so the code cannot compile without it. That commit is the merge of wso2/vscode-extensions#2435 (loopback binding + handshake token auth in `@wso2/webview-giga-bridge`).

## User stories

As a developer running WSO2 Integrator, another user on my network (or a web page I merely visit) must not be able to connect to the extension's local bridge and execute commands or read my cloud credentials.

## Release note

Fixed an unauthenticated local websocket bridge in the WSO2 Integrator welcome page and restricted the commands the webview may invoke.

## Documentation

N/A — no user-facing behaviour or configuration changes. The token is generated and consumed internally.

## Training

N/A

## Certification

N/A — internal transport hardening, no impact on certification exam content.

## Marketing

N/A

## Automation tests

- Unit tests
  > No unit-test harness exists for `BridgeLayer` / `MainWsManager` in this package, so none were added. Verification was done by build and typecheck (below).
- Integration tests
  > None added. The websocket path is exercised only in `WEB_VIEW_DEV_MODE` and by the embedded welcome flow, neither of which currently has automated coverage.

**Verification performed:**
- `wi-extension` typechecks clean (0 errors)
- `wi-core` builds and emits `wsToken?: string`
- `wi-webviews` reports 0 errors in `WsClient.ts`
- `WICommandIds` confirmed to export exactly the four ids referenced by the allowlist

**Known gap:** `wi-webviews` still reports 34 errors in this local partial build — 26 `Cannot find module '@wso2/ui-toolkit'` plus 8 cascading implicit-any in two of its consumers. These are pre-existing and unrelated: none are in files touched here, both implicit-any files import `ui-toolkit`, and `ui-toolkit` was not built locally. A full `rush build` (as CI runs) builds it first.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
- Ran FindSecurityBugs plugin and verified report? **N/A** — TypeScript codebase, not Java
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes** — the token is generated at runtime via `randomBytes(32)` and never persisted or committed

## Samples

N/A

## Related PRs

- wso2/vscode-extensions#2435 — the `@wso2/webview-giga-bridge` change this depends on (loopback bind + handshake token auth). Already merged; picked up here via the submodule bump.

## Migrations (if applicable)

None. No persisted state or configuration is affected.

## Test environment

macOS (darwin 25.5.0), Node 22.21.1, Rush 5.177.1 / pnpm 10.11.0.

## Learning

The non-obvious constraint was that `brace-expansion`-style "just take the latest fixed version" reasoning does not apply to transport auth: enforcing the token per **request** (as the Ballerina `DefaultServer` does) still lets an unauthenticated client connect and passively receive broadcast events. Gating at the handshake closes both paths at once, which is why the library change exposes `verifyClient` rather than a per-message check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Added token-based authentication for embedded webview WebSocket connections.
  * Restricted webview-invoked actions to approved commands.
  * Strengthened embedded Welcome content with per-render CSP nonces.

* **New Features**
  * Added an improved empty-workspace Welcome experience with WSO2 login support.

* **Reliability**
  * Ensured webviews wait for bridge startup and report startup errors.

* **Compatibility**
  * Updated bundled WSO2 VS Code extensions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->