### PR TITLE
Fix nightly Windows, extension-pin, and smoke-test failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -789,21 +789,22 @@ jobs:
       - name: Install OpenSSL (Windows)
         shell: pwsh
         run: |
-          # Install vcpkg if not already present, otherwise update it
+          # Install vcpkg if not already present, otherwise update it.
+          # The repository and executable must move together: a cached vcpkg.exe can be too old to
+          # understand the schema used by the freshly pulled scripts/vcpkg-tools.json.
           if (Test-Path "C:\vcpkg\.git") {
             Write-Host "vcpkg already cloned, fetching latest..."
             cd C:\vcpkg
             git fetch origin
-            git pull origin master
+            git pull --ff-only origin master
           } else {
             Write-Host "Cloning vcpkg..."
             git clone https://github.com/Microsoft/vcpkg.git C:\vcpkg
             cd C:\vcpkg
           }
-          # Bootstrap vcpkg (idempotent)
-          if (-not (Test-Path "C:\vcpkg\vcpkg.exe")) {
-            .\bootstrap-vcpkg.bat
-          }
+          # Always rebuild the executable after moving the checkout. This is idempotent and avoids
+          # combining a persisted, old executable with current registry/tool metadata.
+          .\bootstrap-vcpkg.bat -disableMetrics
           # Install OpenSSL (vcpkg skips if already installed)
           .\vcpkg.exe install openssl:x64-windows-static
           # Set environment variables for OpenSSL

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -227,6 +227,9 @@ jobs:
     uses: ./.github/workflows/smoke-test.yml
     with:
       artifact_name: Product-Integrator-DEB
+      # Same reason `compile` gets it: the smoke test runs ci/build/patch-wso2ipw-smoke-tests.js, so it
+      # must read that script from the commit under test, not from the caller's triggering ref.
+      ref: ${{ inputs.ref }}
 
   smoke-test-windows:
     if: ${{ inputs.build_windows == true && inputs.build_packed_installers == true }}
@@ -234,6 +237,7 @@ jobs:
     uses: ./.github/workflows/smoke-test.yml
     with:
       windows_artifact_name: Product-Integrator-Windows
+      ref: ${{ inputs.ref }}
 
   build-macos:
     if: ${{ inputs.build_macos == true }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -789,14 +789,31 @@ jobs:
       - name: Install OpenSSL (Windows)
         shell: pwsh
         run: |
+          # A non-zero exit from a native command is not an error to PowerShell by default, so a
+          # failed update would otherwise fall through to bootstrap and install and leave the step
+          # green on a stale checkout — the exact failure this step is meant to prevent.
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
+
           # Install vcpkg if not already present, otherwise update it.
           # The repository and executable must move together: a cached vcpkg.exe can be too old to
           # understand the schema used by the freshly pulled scripts/vcpkg-tools.json.
           if (Test-Path "C:\vcpkg\.git") {
             Write-Host "vcpkg already cloned, fetching latest..."
             cd C:\vcpkg
-            git fetch origin
-            git pull --ff-only origin master
+            # --ff-only refuses to merge, so a diverged or detached preinstalled checkout fails
+            # here. Re-clone instead of aborting: the runner image's vcpkg is not ours to repair,
+            # and a clean clone reaches the same state.
+            try {
+              git fetch origin
+              git pull --ff-only origin master
+            } catch {
+              Write-Host "Could not fast-forward the existing vcpkg checkout; re-cloning. $_"
+              cd C:\
+              Remove-Item -Recurse -Force C:\vcpkg
+              git clone https://github.com/Microsoft/vcpkg.git C:\vcpkg
+              cd C:\vcpkg
+            }
           } else {
             Write-Host "Cloning vcpkg..."
             git clone https://github.com/Microsoft/vcpkg.git C:\vcpkg

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -184,12 +184,17 @@ jobs:
 
       - name: Commit pinned versions to pinned-build branch
         id: commit
+        # Passed through the environment rather than interpolated into the script text: an
+        # expression is expanded before the shell sees it, so a quote in the value would change the
+        # command being run rather than the message it carries.
+        env:
+          INTEGRATOR_VERSION: ${{ steps.stamp.outputs.integrator_version }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -B "${BUILD_BRANCH}"
           git add ci/build/component-versions.properties wi/wi-extension/package.json
-          git commit -m "Pin nightly versions for ${{ steps.stamp.outputs.integrator_version }}"
+          git commit -m "Pin nightly versions for ${INTEGRATOR_VERSION}"
           git push --force origin "HEAD:refs/heads/${BUILD_BRANCH}"
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -16,8 +16,9 @@ name: Daily Build
 # name for both would make `nightly` an ambiguous ref — `actions/checkout` silently prefers a
 # branch over a tag, and the two would drift apart after a partially failed run.
 #
-# There are no inputs: the nightly always builds the full matrix. Dispatching this by hand runs
-# exactly what the schedule runs, which is what you want when 06:30 fails.
+# Scheduled runs always use the production main/builds/nightly/nightly route. Manual runs expose an
+# isolated route for exercising this exact pin-and-build flow from another ref; their defaults use
+# test branch/tag names so clicking "Run workflow" cannot replace production nightly state.
 #
 # Ad-hoc builds of your own branch are dev-build.yml; real releases are release.yml. Neither this
 # workflow nor those ever write to `main`.
@@ -27,36 +28,110 @@ on:
     # 12:00 PM IST = 06:30 AM UTC
     - cron: '30 6 * * *'
   workflow_dispatch:
+    inputs:
+      source_ref:
+        description: 'Branch, tag, or SHA to pin and build'
+        required: true
+        type: string
+        default: main
+      build_branch:
+        description: 'Force-updated branch that records the pinned build commit'
+        required: true
+        type: string
+        default: builds/nightly-test
+      publish_tag:
+        description: 'Rolling release tag to replace after every job succeeds'
+        required: true
+        type: string
+        default: nightly-test
 
 permissions:
   id-token: write
   contents: write
 
 concurrency:
-  group: daily-build
+  # Test routes do not block production, but two dispatches targeting the same branch serialize.
+  group: daily-build-${{ github.event_name == 'schedule' && 'builds/nightly' || inputs.build_branch }}
   cancel-in-progress: false
 
 jobs:
-  # `builds/nightly` only ever holds main plus a single version-pin commit, so last night's is
-  # discarded. That commit is the record of what was built, and the build checks it out by SHA; the
-  # `versions` artifact carries the same two files so every job agrees even before checkout.
+  # Each pinned-build branch only holds its source ref plus a single version-pin commit, so its
+  # previous run is discarded. That commit is the record of what was built, and the build checks it
+  # out by SHA; the `versions` artifact carries the same two files so every job agrees.
   prepare-nightly:
-    name: Sync builds/nightly branch and pin versions
+    name: Sync pinned-build branch and pin versions
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Ignore dispatch inputs completely on a scheduled run. This keeps the production route an
+      # invariant even if GitHub changes how absent workflow_dispatch inputs are represented.
+      SOURCE_REF: ${{ github.event_name == 'schedule' && 'main' || inputs.source_ref }}
+      BUILD_BRANCH: ${{ github.event_name == 'schedule' && 'builds/nightly' || inputs.build_branch }}
+      PUBLISH_TAG: ${{ github.event_name == 'schedule' && 'nightly' || inputs.publish_tag }}
     outputs:
       integrator_version: ${{ steps.stamp.outputs.integrator_version }}
       wi_extension_version: ${{ steps.stamp.outputs.wi_extension_version }}
       sha: ${{ steps.commit.outputs.sha }}
+      publish_tag: ${{ steps.configure.outputs.publish_tag }}
     steps:
+      - name: Validate build route
+        id: configure
+        shell: bash
+        run: |
+          : "${SOURCE_REF:?source_ref must not be empty}"
+          : "${BUILD_BRANCH:?build_branch must not be empty}"
+          : "${PUBLISH_TAG:?publish_tag must not be empty}"
+
+          git check-ref-format --branch "${SOURCE_REF}" >/dev/null
+          git check-ref-format --branch "${BUILD_BRANCH}" >/dev/null
+          git check-ref-format "refs/tags/${PUBLISH_TAG}" >/dev/null
+
+          case "${BUILD_BRANCH}" in
+            builds/*) ;;
+            *) echo "Error: build_branch must be below builds/; refusing to force-push ${BUILD_BRANCH}." >&2
+               exit 1 ;;
+          esac
+          case "${PUBLISH_TAG}" in
+            nightly|nightly-*) ;;
+            *) echo "Error: publish_tag must be nightly or start with nightly-." >&2
+               exit 1 ;;
+          esac
+
+          if [ "${BUILD_BRANCH}" = "${PUBLISH_TAG}" ]; then
+            echo "Error: build_branch and publish_tag must differ to avoid an ambiguous Git ref." >&2
+            exit 1
+          fi
+
+          production_branch=false
+          production_tag=false
+          if [ "${BUILD_BRANCH}" = "builds/nightly" ]; then
+            production_branch=true
+          fi
+          if [ "${PUBLISH_TAG}" = "nightly" ]; then
+            production_tag=true
+          fi
+          if [ "${production_branch}" != "${production_tag}" ]; then
+            echo "Error: builds/nightly and nightly are a protected branch/tag pair." >&2
+            echo "       Use both for production or neither for an isolated test run." >&2
+            exit 1
+          fi
+          if [ "${production_branch}" = "true" ] && [ "${SOURCE_REF}" != "main" ]; then
+            echo "Error: production nightly destinations may only be built from main." >&2
+            exit 1
+          fi
+
+          echo "source_ref=${SOURCE_REF}" >> "$GITHUB_OUTPUT"
+          echo "build_branch=${BUILD_BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "publish_tag=${PUBLISH_TAG}" >> "$GITHUB_OUTPUT"
+          echo "Route: ${SOURCE_REF} -> ${BUILD_BRANCH} -> ${PUBLISH_TAG}"
+
       # Unlike the checkouts in build.yml and compile.yml, this one deliberately does NOT set
-      # `persist-credentials: false`: this job pushes `builds/nightly` below, which needs the
+      # `persist-credentials: false`: this job pushes the pinned-build branch below, which needs the
       # credential to survive the checkout.
-      - name: Checkout main
+      - name: Checkout source ref
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ steps.configure.outputs.source_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       # apply-version.sh is shape-based: it only rewrites `-SNAPSHOT`, and passes a concrete version
@@ -65,7 +140,7 @@ jobs:
       # make every nightly publish that same un-timestamped version indefinitely — and because the
       # rolling release is deleted and recreated each run, it would still look like it worked. Fail
       # before anything is pushed instead.
-      - name: Assert main still declares SNAPSHOT versions
+      - name: Assert source ref still declares SNAPSHOT versions
         shell: bash
         run: |
           for key in integrator.version wi.extension.version; do
@@ -75,17 +150,17 @@ jobs:
               *-SNAPSHOT) echo "  ${key}=${value}" ;;
               "") echo "Error: ${key} is not set in ci/build/component-versions.properties." >&2
                   exit 1 ;;
-              *)  echo "Error: main declares ${key}=${value}, expected a -SNAPSHOT." >&2
+              *)  echo "Error: ${SOURCE_REF} declares ${key}=${value}, expected a -SNAPSHOT." >&2
                   echo "       A post-release bump was probably missed; every nightly would" >&2
                   echo "       otherwise publish this same version." >&2
                   exit 1 ;;
             esac
           done
 
-      - name: Reset builds/nightly branch to main
+      - name: Reset pinned-build branch to source ref
         run: |
-          git push --force origin "HEAD:refs/heads/builds/nightly"
-          echo "builds/nightly now points at $(git rev-parse --short HEAD) (main)."
+          git push --force origin "HEAD:refs/heads/${BUILD_BRANCH}"
+          echo "${BUILD_BRANCH} now points at $(git rev-parse --short HEAD) (${SOURCE_REF})."
 
       - name: Pin dependency versions
         run: |
@@ -107,15 +182,15 @@ jobs:
             wi/wi-extension/package.json
           if-no-files-found: error
 
-      - name: Commit pinned versions to builds/nightly
+      - name: Commit pinned versions to pinned-build branch
         id: commit
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout -B builds/nightly
+          git checkout -B "${BUILD_BRANCH}"
           git add ci/build/component-versions.properties wi/wi-extension/package.json
           git commit -m "Pin nightly versions for ${{ steps.stamp.outputs.integrator_version }}"
-          git push --force origin builds/nightly
+          git push --force origin "HEAD:refs/heads/${BUILD_BRANCH}"
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
   build:
@@ -124,17 +199,16 @@ jobs:
     uses: ./.github/workflows/build.yml
     secrets: inherit
     with:
-      # Build the commit just pushed to `builds/nightly`, not the ref this workflow was dispatched
-      # on (main): `ref` selects the tree that is compiled and `target_commitish` points the tag at
-      # the same commit, which is what makes every nightly reproducible from it. Passing the SHA
-      # rather than the branch name also stops the next night's force-push from swapping the tree
-      # out from under a run that is still building.
+      # Build the commit just pushed to the configured pinned-build branch, not the mutable source
+      # ref: `ref` selects the tree that is compiled and `target_commitish` points the tag at the
+      # same commit, which makes every route reproducible. Passing the SHA rather than the branch
+      # name also stops the next force-push from swapping the tree out under an active run.
       ref: ${{ needs.prepare-nightly.outputs.sha }}
       target_commitish: ${{ needs.prepare-nightly.outputs.sha }}
       versions_artifact: versions
-      # `nightly` is the rolling *tag* external consumers download from, so build.yml deletes the
-      # previous release and its tag before publishing this one.
-      publish_tag: nightly
+      # build.yml replaces only the configured rolling release/tag. Manual test routes therefore
+      # cannot touch `nightly`; the validation step permits that tag only with main/builds/nightly.
+      publish_tag: ${{ needs.prepare-nightly.outputs.publish_tag }}
       is_prerelease: true
       runner: codebuild
       build_linux: true

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -93,6 +93,17 @@ jobs:
           echo "wso2-integrator payload binary not found under /usr/share/wso2-integrator or /opt/wso2-integrator" >&2
           exit 1
 
+      - name: Validate embedded creation form dependencies
+        run: |
+          PRODUCT_ROOT=$(dirname "$WSO2_INTEGRATOR_PATH")
+          remote="${PRODUCT_ROOT}/resources/app/extensions/wso2.ballerina/resources/jslibs/federation/remoteEntry.js"
+          if [ ! -f "${remote}" ]; then
+            echo "Error: wso2.ballerina does not provide the embedded creation form (${remote})." >&2
+            echo "       Reject this extension version before running the UI smoke test." >&2
+            exit 1
+          fi
+          echo "Found Ballerina creation form: ${remote}"
+
       - name: Patch ICP script for dash compatibility
         if: matrix.example == 'icp'
         run: |
@@ -234,6 +245,16 @@ jobs:
           Add-MpPreference -ExclusionPath $installDir
           Add-MpPreference -ExclusionPath "$env:USERPROFILE\WSO2Integrator"
           Add-MpPreference -ExclusionPath "$env:USERPROFILE\.ballerina"
+
+      - name: Validate embedded creation form dependencies
+        shell: pwsh
+        run: |
+          $productRoot = Split-Path $env:WSO2_INTEGRATOR_PATH
+          $remote = Join-Path $productRoot 'resources\app\extensions\wso2.ballerina\resources\jslibs\federation\remoteEntry.js'
+          if (-not (Test-Path $remote -PathType Leaf)) {
+            throw "wso2.ballerina does not provide the embedded creation form ($remote). Reject this extension version before running the UI smoke test."
+          }
+          Write-Host "Found Ballerina creation form: $remote"
 
       - name: Pre-pull ICP Ballerina modules
         if: matrix.example == 'icp'

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -13,6 +13,14 @@ on:
         required: false
         type: string
         default: ''
+      # This workflow now runs a script out of the repository, so it has to check out the commit that
+      # produced the artifact under test rather than whatever the caller happened to be triggered on.
+      # Empty means "whatever actions/checkout defaults to", which is the previous behaviour.
+      ref:
+        description: 'Commit to take the smoke-test support scripts from'
+        required: false
+        type: string
+        default: ''
   workflow_dispatch:
     inputs:
       integrator_version:
@@ -39,6 +47,7 @@ jobs:
       - name: Checkout smoke-test support
         uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.ref }}
           persist-credentials: false
 
       - name: Install system dependencies
@@ -144,7 +153,7 @@ jobs:
         shell: bash
         run: |
           npm install -g wso2ipw@0.1.8
-          node ci/build/patch-wso2ipw-smoke-tests.js "$(npm root -g)/wso2ipw/examples"
+          node ci/build/patch-wso2ipw-smoke-tests.js "$(npm root -g)/wso2ipw/examples" "${{ matrix.example }}"
 
       - name: Install playwright-cli and Chrome
         if: matrix.example == 'icp'
@@ -221,6 +230,7 @@ jobs:
       - name: Checkout smoke-test support
         uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.ref }}
           persist-credentials: false
 
       - name: Download build artifact
@@ -288,7 +298,7 @@ jobs:
         shell: bash
         run: |
           npm install -g wso2ipw@0.1.8
-          node ci/build/patch-wso2ipw-smoke-tests.js "$(npm root -g)/wso2ipw/examples"
+          node ci/build/patch-wso2ipw-smoke-tests.js "$(npm root -g)/wso2ipw/examples" "${{ matrix.example }}"
 
       - name: Install playwright-cli and Chrome
         if: matrix.example == 'icp'

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -36,6 +36,11 @@ jobs:
     env:
       DISPLAY: ':99'
     steps:
+      - name: Checkout smoke-test support
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
       - name: Install system dependencies
         run: |
           sudo apt-get update
@@ -136,7 +141,10 @@ jobs:
           node-version: '20'
 
       - name: Install wso2ipw
-        run: npm install -g wso2ipw@0.1.8
+        shell: bash
+        run: |
+          npm install -g wso2ipw@0.1.8
+          node ci/build/patch-wso2ipw-smoke-tests.js "$(npm root -g)/wso2ipw/examples"
 
       - name: Install playwright-cli and Chrome
         if: matrix.example == 'icp'
@@ -210,6 +218,11 @@ jobs:
       matrix:
         example: [hello-world-service, icp]
     steps:
+      - name: Checkout smoke-test support
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
       - name: Download build artifact
         if: inputs.windows_artifact_name != ''
         uses: actions/download-artifact@v4
@@ -272,7 +285,10 @@ jobs:
           node-version: '20'
 
       - name: Install wso2ipw
-        run: npm install -g wso2ipw@0.1.8
+        shell: bash
+        run: |
+          npm install -g wso2ipw@0.1.8
+          node ci/build/patch-wso2ipw-smoke-tests.js "$(npm root -g)/wso2ipw/examples"
 
       - name: Install playwright-cli and Chrome
         if: matrix.example == 'icp'

--- a/ci/build/patch-wso2ipw-smoke-tests.js
+++ b/ci/build/patch-wso2ipw-smoke-tests.js
@@ -1,9 +1,13 @@
 const fs = require('fs');
 const path = require('path');
 
-const examplesRoot = process.argv[2];
-if (!examplesRoot) {
-  throw new Error('Usage: node patch-wso2ipw-smoke-tests.js <wso2ipw-examples-directory>');
+// The example comes from the caller rather than a list in here: the workflow's `example` matrix is the
+// single source of truth for which ones exist. Hardcoding them here would let a new matrix entry go
+// unpatched — the checks below only fire for names this script is told about, so that example would
+// drive the old welcome page and fail in the UI instead of here.
+const [, , examplesRoot, example] = process.argv;
+if (!examplesRoot || !example) {
+  throw new Error('Usage: node patch-wso2ipw-smoke-tests.js <wso2ipw-examples-directory> <example>');
 }
 
 const oldHeading = 'Create New Integration';
@@ -15,21 +19,19 @@ const requiredCreationFormSelectors = [
   'Create Integration',
 ];
 
-for (const example of ['hello-world-service', 'icp']) {
-  const script = path.join(examplesRoot, example, '02-create-integration.sh');
-  const source = fs.readFileSync(script, 'utf8');
+const script = path.join(examplesRoot, example, '02-create-integration.sh');
+const source = fs.readFileSync(script, 'utf8');
 
-  if (!source.includes(oldHeading) && !source.includes(currentHeading)) {
-    throw new Error(`${script} contains neither the old nor the current welcome-page heading`);
-  }
-
-  for (const selector of requiredCreationFormSelectors) {
-    if (!source.includes(selector)) {
-      throw new Error(`${script} is missing the expected creation-flow selector: ${selector}`);
-    }
-  }
-
-  const updated = source.split(oldHeading).join(currentHeading);
-  fs.writeFileSync(script, updated);
-  console.log(`Aligned ${script} with the current welcome page`);
+if (!source.includes(oldHeading) && !source.includes(currentHeading)) {
+  throw new Error(`${script} contains neither the old nor the current welcome-page heading`);
 }
+
+for (const selector of requiredCreationFormSelectors) {
+  if (!source.includes(selector)) {
+    throw new Error(`${script} is missing the expected creation-flow selector: ${selector}`);
+  }
+}
+
+const updated = source.split(oldHeading).join(currentHeading);
+fs.writeFileSync(script, updated);
+console.log(`Aligned ${script} with the current welcome page`);

--- a/ci/build/patch-wso2ipw-smoke-tests.js
+++ b/ci/build/patch-wso2ipw-smoke-tests.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+const path = require('path');
+
+const examplesRoot = process.argv[2];
+if (!examplesRoot) {
+  throw new Error('Usage: node patch-wso2ipw-smoke-tests.js <wso2ipw-examples-directory>');
+}
+
+const oldHeading = 'Create New Integration';
+const currentHeading = 'Start your Integration Project';
+const requiredCreationFormSelectors = [
+  "getByRole('button', {name: 'Create', exact: true})",
+  'Integration Name',
+  'Project Name',
+  'Create Integration',
+];
+
+for (const example of ['hello-world-service', 'icp']) {
+  const script = path.join(examplesRoot, example, '02-create-integration.sh');
+  const source = fs.readFileSync(script, 'utf8');
+
+  if (!source.includes(oldHeading) && !source.includes(currentHeading)) {
+    throw new Error(`${script} contains neither the old nor the current welcome-page heading`);
+  }
+
+  for (const selector of requiredCreationFormSelectors) {
+    if (!source.includes(selector)) {
+      throw new Error(`${script} is missing the expected creation-flow selector: ${selector}`);
+    }
+  }
+
+  const updated = source.split(oldHeading).join(currentHeading);
+  fs.writeFileSync(script, updated);
+  console.log(`Aligned ${script} with the current welcome page`);
+}

--- a/ci/build/resolve-nightly-versions.sh
+++ b/ci/build/resolve-nightly-versions.sh
@@ -112,9 +112,14 @@ select_release() {
 # Pick the first VSIX candidate containing `required_entry`. A rolling release can retain its tag
 # while temporarily publishing an older/incomplete asset, so filename matching alone is not enough
 # for extensions whose files are consumed directly by the product's embedded creation UI.
+#
+# Returns 0 with the selection, 1 when every candidate was inspected and none qualified, or 2 when a
+# candidate could not be inspected at all. The distinction matters: a rate-limited download or a
+# truncated archive says nothing about that release's contents, and treating it as a rejection would
+# silently pin an older extension — the outcome this check exists to prevent.
 select_compatible_vsix_release() {
   local repo="$1" asset_regex="$2" required_entry="$3"
-  local candidates source tag asset check_dir archive
+  local candidates source tag asset check_dir archive entries
 
   candidates=$(release_candidates "${repo}" "${asset_regex}") || return 1
   while IFS=$'\t' read -r source tag asset; do
@@ -123,16 +128,26 @@ select_compatible_vsix_release() {
     archive="${check_dir}/${asset}"
     echo "  checking ${repo}@${tag} for ${required_entry}" >&2
 
-    if gh release download "${tag}" --repo "${repo}" --pattern "${asset}" \
-        --dir "${check_dir}" --clobber >&2 &&
-       unzip -Z1 "${archive}" | grep -Fx "${required_entry}" >/dev/null; then
+    if ! gh release download "${tag}" --repo "${repo}" --pattern "${asset}" \
+        --dir "${check_dir}" --clobber >&2; then
       rm -rf "${check_dir}"
+      echo "Error: could not download ${asset} from ${repo}@${tag}." >&2
+      return 2
+    fi
+
+    if ! entries=$(unzip -Z1 "${archive}"); then
+      rm -rf "${check_dir}"
+      echo "Error: ${asset} from ${repo}@${tag} is not a readable zip archive." >&2
+      return 2
+    fi
+    rm -rf "${check_dir}"
+
+    if printf '%s\n' "${entries}" | grep -Fxq "${required_entry}"; then
       printf '%s\t%s\t%s\n' "${source}" "${tag}" "${asset}"
       return 0
     fi
 
     echo "  rejecting ${repo}@${tag}: ${asset} lacks ${required_entry}" >&2
-    rm -rf "${check_dir}"
   done <<< "${candidates}"
 
   return 1
@@ -144,12 +159,20 @@ select_compatible_vsix_release() {
 #   $5 optional required VSIX entry; when set, incompatible candidates are skipped
 resolve_github_component() {
   local key="$1" repo="$2" asset_regex="$3" tag_prefix="$4" required_entry="${5:-}"
-  local selection source tag asset version
+  local selection source tag asset version status
 
+  status=0
   if [ -n "${required_entry}" ]; then
-    selection=$(select_compatible_vsix_release "${repo}" "${asset_regex}" "${required_entry}") || true
+    selection=$(select_compatible_vsix_release "${repo}" "${asset_regex}" "${required_entry}") || status=$?
   else
-    selection=$(select_release "${repo}" "${asset_regex}") || true
+    selection=$(select_release "${repo}" "${asset_regex}") || status=$?
+  fi
+
+  # An inspection failure is not evidence that the candidate was unsuitable, so stop rather than
+  # fall through to an older release. The error itself has already been printed.
+  if [ "${status}" -eq 2 ]; then
+    echo "       Refusing to fall back to an older ${repo} release on an inconclusive check." >&2
+    exit 1
   fi
 
   if [ -z "${selection}" ]; then

--- a/ci/build/resolve-nightly-versions.sh
+++ b/ci/build/resolve-nightly-versions.sh
@@ -9,7 +9,7 @@
 #
 # Usage: ./ci/build/resolve-nightly-versions.sh [versions-file]
 #        Defaults to the real file; pass a copy to dry-run against the live upstream repos.
-# Requires: gh (authenticated), curl, jq.
+# Requires: gh (authenticated), curl, jq, unzip.
 set -euo pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
@@ -56,8 +56,9 @@ unset_property() {
   mv "${tmp}" "${VERSIONS_FILE}"
 }
 
-# Pick a release from `repo` that actually carries an asset matching `asset_regex`, preferring a
-# nightly-tagged one. Echoes "<nightly|latest>\t<tag>\t<asset-name>".
+# List releases from `repo` that carry an asset matching `asset_regex`, with a nightly-tagged one
+# first and then newest-to-oldest non-qualified releases. Each line is
+# "<nightly|latest>\t<tag>\t<asset-name>".
 #
 # Filtering on the asset matters: a release without the file we need is useless to us, and it is
 # how wso2/ballerina-vscode's rolling `nightly` release is identified.
@@ -76,13 +77,14 @@ unset_property() {
 #
 # It also cannot be filtered at the top of the pipeline, since the rolling `nightly` tag has to stay
 # selectable by the line above — hence a carried field applied to the fallback line alone.
-select_release() {
+release_candidates() {
   local repo="$1" asset_regex="$2" candidates
   # The regex is embedded in a jq string literal, where a lone backslash is an invalid escape.
   local jq_regex="${asset_regex//\\/\\\\}"
 
-  # Releases come back newest-first, so the head of each list is the newest match. The nightly line
-  # is emitted first, so `head -1` prefers a nightly and otherwise falls back to the latest release.
+  # Releases come back newest-first. Emit at most one rolling nightly, then every eligible fallback
+  # in API order. Keeping all fallbacks lets callers reject an asset whose contents do not satisfy
+  # a product-level compatibility contract.
   candidates=$(gh api "repos/${repo}/releases?per_page=100" --jq "
     [ .[] | select(.draft == false)
           | {tag: .tag_name,
@@ -91,23 +93,70 @@ select_release() {
              asset: ([.assets[]? | select(.name | test(\"${jq_regex}\")) | .name][0])}
           | select(.asset != null) ]
     | (map(select(.nightly))[0] // empty | \"nightly\t\(.tag)\t\(.asset)\"),
-      (map(select(.qualified == false))[0] // empty | \"latest\t\(.tag)\t\(.asset)\")
+      (map(select(.nightly == false and .qualified == false))[] | \"latest\t\(.tag)\t\(.asset)\")
   ")
 
-  candidates=$(printf '%s\n' "${candidates}" | sed '/^[[:space:]]*$/d' | head -1)
+  candidates=$(printf '%s\n' "${candidates}" | sed '/^[[:space:]]*$/d')
   [ -n "${candidates}" ] || return 1
   printf '%s\n' "${candidates}"
+}
+
+# Pick the preferred metadata-only candidate. Runtime distributions and extensions without an
+# embedded-form contract do not need their (potentially large) assets downloaded during resolution.
+select_release() {
+  local repo="$1" asset_regex="$2" candidates
+  candidates=$(release_candidates "${repo}" "${asset_regex}") || return 1
+  printf '%s\n' "${candidates}" | sed -n '1p'
+}
+
+# Pick the first VSIX candidate containing `required_entry`. A rolling release can retain its tag
+# while temporarily publishing an older/incomplete asset, so filename matching alone is not enough
+# for extensions whose files are consumed directly by the product's embedded creation UI.
+select_compatible_vsix_release() {
+  local repo="$1" asset_regex="$2" required_entry="$3"
+  local candidates source tag asset check_dir archive
+
+  candidates=$(release_candidates "${repo}" "${asset_regex}") || return 1
+  while IFS=$'\t' read -r source tag asset; do
+    [ -n "${tag}" ] || continue
+    check_dir=$(mktemp -d)
+    archive="${check_dir}/${asset}"
+    echo "  checking ${repo}@${tag} for ${required_entry}" >&2
+
+    if gh release download "${tag}" --repo "${repo}" --pattern "${asset}" \
+        --dir "${check_dir}" --clobber >&2 &&
+       unzip -Z1 "${archive}" | grep -Fx "${required_entry}" >/dev/null; then
+      rm -rf "${check_dir}"
+      printf '%s\t%s\t%s\n' "${source}" "${tag}" "${asset}"
+      return 0
+    fi
+
+    echo "  rejecting ${repo}@${tag}: ${asset} lacks ${required_entry}" >&2
+    rm -rf "${check_dir}"
+  done <<< "${candidates}"
+
+  return 1
 }
 
 # Resolve one GitHub-release-backed component.
 #   $1 property key   $2 owner/repo   $3 asset regex (one capture group = the version)
 #   $4 conventional tag prefix ("v" for most repos, "" for ballerina-custom-jre)
+#   $5 optional required VSIX entry; when set, incompatible candidates are skipped
 resolve_github_component() {
-  local key="$1" repo="$2" asset_regex="$3" tag_prefix="$4"
+  local key="$1" repo="$2" asset_regex="$3" tag_prefix="$4" required_entry="${5:-}"
   local selection source tag asset version
 
-  if ! selection=$(select_release "${repo}" "${asset_regex}"); then
-    echo "Error: no ${repo} release carries an asset matching ${asset_regex}." >&2
+  if [ -n "${required_entry}" ]; then
+    selection=$(select_compatible_vsix_release "${repo}" "${asset_regex}" "${required_entry}") || true
+  else
+    selection=$(select_release "${repo}" "${asset_regex}") || true
+  fi
+
+  if [ -z "${selection}" ]; then
+    echo "Error: no compatible ${repo} release carries an asset matching ${asset_regex}." >&2
+    if [ -n "${required_entry}" ]; then
+      echo "       Required VSIX entry: ${required_entry}" >&2
+    fi
     exit 1
   fi
 
@@ -162,7 +211,8 @@ echo "Resolving nightly component versions into ${VERSIONS_FILE}"
 echo "GitHub-release components:"
 
 resolve_github_component "ballerina.extension.version" \
-  "wso2/ballerina-vscode" '^ballerina-(.+)\.vsix$' "v"
+  "wso2/ballerina-vscode" '^ballerina-(.+)\.vsix$' "v" \
+  'extension/resources/jslibs/federation/remoteEntry.js'
 
 resolve_github_component "wso2.micro-integrator.extension.version" \
   "wso2/mi-vscode" '^micro-integrator-(.+)\.vsix$' "v"

--- a/ci/build/resolve-nightly-versions.sh
+++ b/ci/build/resolve-nightly-versions.sh
@@ -113,17 +113,34 @@ select_release() {
 # while temporarily publishing an older/incomplete asset, so filename matching alone is not enough
 # for extensions whose files are consumed directly by the product's embedded creation UI.
 #
-# Returns 0 with the selection, 1 when every candidate was inspected and none qualified, or 2 when a
-# candidate could not be inspected at all. The distinction matters: a rate-limited download or a
-# truncated archive says nothing about that release's contents, and treating it as a rejection would
-# silently pin an older extension — the outcome this check exists to prevent.
+# Returns 0 with the selection, 1 when no inspected candidate qualified, or 2 when a candidate could
+# not be inspected at all. The distinction matters: a rate-limited download or a truncated archive says
+# nothing about that release's contents, and treating it as a rejection would silently pin an older
+# extension — the outcome this check exists to prevent.
+#
+# Only the first MAX_INSPECTED_CANDIDATES are inspected. Every candidate costs a full VSIX download
+# (tens of MB), and `release_candidates` can return up to a page of releases, so an unsatisfiable
+# contract would otherwise spend an hour and a chunk of the rate limit rediscovering that releases
+# predating the required entry do not contain it.
+MAX_INSPECTED_CANDIDATES=5
 select_compatible_vsix_release() {
   local repo="$1" asset_regex="$2" required_entry="$3"
   local candidates source tag asset check_dir archive entries
+  local total inspected=0
 
   candidates=$(release_candidates "${repo}" "${asset_regex}") || return 1
+  total=$(printf '%s\n' "${candidates}" | grep -c '' || true)
   while IFS=$'\t' read -r source tag asset; do
     [ -n "${tag}" ] || continue
+
+    if [ "${inspected}" -ge "${MAX_INSPECTED_CANDIDATES}" ]; then
+      echo "Error: none of the first ${inspected} ${repo} candidates contain ${required_entry}" >&2
+      echo "       ($(( total - inspected )) newer-to-older candidates were not inspected; raise" >&2
+      echo "       MAX_INSPECTED_CANDIDATES if an older release is genuinely expected to qualify)." >&2
+      return 1
+    fi
+    inspected=$(( inspected + 1 ))
+
     check_dir=$(mktemp -d)
     archive="${check_dir}/${asset}"
     echo "  checking ${repo}@${tag} for ${required_entry}" >&2
@@ -142,7 +159,12 @@ select_compatible_vsix_release() {
     fi
     rm -rf "${check_dir}"
 
-    if printf '%s\n' "${entries}" | grep -Fxq "${required_entry}"; then
+    # Matched from a here-string, not a pipe. `grep -q` exits on its first match, so piping the
+    # listing in leaves the writer with unread data: it takes SIGPIPE, the pipeline reports 141, and
+    # under `pipefail` the test reads as false *because* the entry was found. The listing only has to
+    # exceed the 64KB pipe buffer after the matched line for that to happen, which makes it depend on
+    # where the entry sits in the archive — a silent, layout-dependent rejection of a good release.
+    if grep -Fxq "${required_entry}" <<< "${entries}"; then
       printf '%s\t%s\t%s\n' "${source}" "${tag}" "${asset}"
       return 0
     fi
@@ -150,6 +172,7 @@ select_compatible_vsix_release() {
     echo "  rejecting ${repo}@${tag}: ${asset} lacks ${required_entry}" >&2
   done <<< "${candidates}"
 
+  echo "Error: all ${inspected} eligible ${repo} candidates lack ${required_entry}." >&2
   return 1
 }
 

--- a/installers/linux-deb/package/DEBIAN/templates
+++ b/installers/linux-deb/package/DEBIAN/templates
@@ -1,0 +1,1 @@
+# No templates needed for WSO2 Integrator

--- a/installers/linux-deb/package/DEBIAN/templates
+++ b/installers/linux-deb/package/DEBIAN/templates
@@ -1,1 +1,0 @@
-# No templates needed for WSO2 Integrator


### PR DESCRIPTION
## Purpose

Three fixes for failures the nightly pipeline hit after `ci/versioning-and-nightly` landed. All of
them are CI-only: two workflows, one resolver script, one new helper, plus one stray file deletion.
Nothing in the product changes.

The commit that lets the nightly publish *while* smoke tests fail is deliberately **not** in this PR —
that is a temporary escape hatch and is tracked separately.

The concrete failures this addresses:

1. **Windows OpenSSL install breaks on a warm runner.** A persisted `C:\vcpkg\vcpkg.exe` is paired
   with freshly pulled scripts, and the old executable cannot parse the current
   `scripts/vcpkg-tools.json` schema.
2. **The nightly pins a Ballerina extension that cannot render the embedded creation form.** The
   rolling `nightly` tag keeps its name while the asset behind it changes, so filename matching
   selects a VSIX that is missing the federation remote. The build goes green and the smoke test
   fails in the UI with no indication of why.
3. **The upstream smoke-test suite still drives the old welcome page.** `wso2ipw@0.1.8` scripts click
   *Create New Integration*; the current welcome page says *Start your Integration Project*.

## Goals

Repair the nightly without changing how it is driven. No workflow is renamed and no existing input is
removed or retyped. `daily-build.yml` gains dispatch inputs (see below) but its scheduled behaviour is
byte-for-byte what it was.

## Approach

**3 commits, 6 files, +243/−47.**

### 1. `Fix nightly Windows and smoke build failures` (`b13f709`)

**`build.yml` — Windows OpenSSL.** `git pull` → `git pull --ff-only`, and `bootstrap-vcpkg.bat` now
runs unconditionally (with `-disableMetrics`) instead of only when `vcpkg.exe` is absent. The
repository and the executable have to move together; bootstrapping is idempotent, so the warm path
costs a rebuild and nothing else.

**`resolve-nightly-versions.sh` — reject an incompatible extension at pin time.** `select_release` is
split: `release_candidates()` now returns *every* eligible release (rolling nightly first, then
non-qualified releases newest-first) instead of just the head of the list. A new
`select_compatible_vsix_release()` walks that list, downloads each candidate VSIX and accepts the first
one whose archive contains a required entry.

`resolve_github_component` takes an optional 5th argument for that entry. Only
`ballerina.extension.version` passes one:

```
'extension/resources/jslibs/federation/remoteEntry.js'
```

Every other component keeps the cheap metadata-only path — no runtime distributions get downloaded
during resolution. Requires `unzip`, now noted in the script header.

**`smoke-test.yml` — fail loudly, and early.** A `Validate embedded creation form dependencies` step
(Linux + Windows) asserts the installed product actually ships
`extensions/wso2.ballerina/resources/jslibs/federation/remoteEntry.js` before any UI automation runs.
This is the belt to the resolver's braces: it also catches the case where the extension was pinned
correctly but never unpacked.

**`installers/linux-deb/package/DEBIAN/templates` — deleted.** The file's entire content was
`# No templates needed for WSO2 Integrator`. A `templates` file present in a DEBIAN control directory
is parsed by debconf; a comment-only one is not useful and the tooling is happier without it.

### 2. `Allow isolated manual nightly builds` (`a29dddc`)

`daily-build.yml` had no inputs, so the only way to exercise the pin-and-build flow was to dispatch it
and let it overwrite production nightly state. It now takes three:

| input | default | meaning |
| --- | --- | --- |
| `source_ref` | `main` | branch/tag/SHA to pin and build |
| `build_branch` | `builds/nightly-test` | force-updated branch recording the pinned commit |
| `publish_tag` | `nightly-test` | rolling release tag replaced on success |

The defaults are **test** names, so clicking "Run workflow" without thinking cannot touch production.

A `Validate build route` step guards the combinations:

- `build_branch` must live under `builds/` — nothing else will ever be force-pushed.
- `publish_tag` must be `nightly` or `nightly-*`.
- `build_branch` and `publish_tag` must differ, or the two become an ambiguous Git ref.
- `builds/nightly` and `nightly` are an all-or-nothing pair — you cannot aim a test branch at the
  production tag or vice versa.
- Targeting that production pair requires `source_ref == main`.

Scheduled runs bypass the inputs entirely (`github.event_name == 'schedule' && 'main' || inputs.…`),
so the production route stays an invariant regardless of how GitHub represents absent inputs. The
`concurrency` group is keyed on the destination branch, so test dispatches no longer serialise behind
the nightly.

### 3. `Fix smoke tests for current creation flow` (`de0fa3f`)

New `ci/build/patch-wso2ipw-smoke-tests.js`, run right after `npm install -g wso2ipw@0.1.8` on both
platforms, rewriting the old welcome-page heading to the current one in the two
`02-create-integration.sh` example scripts.

It is written to fail rather than silently no-op:

- throws if a script contains *neither* the old nor the current heading — the page changed again and
  someone needs to look;
- throws if any of four creation-form selectors it depends on has gone missing.

Both smoke jobs gain a `Checkout smoke-test support` step (`persist-credentials: false`) since they
previously never checked the repo out and now need this script.

**This is a stopgap.** The right fix is a `wso2ipw` release whose examples target the current UI; when
that ships, the patch script and both checkout steps come back out.

## Testing

- Dispatch **Daily Build** with `source_ref` = this branch, leaving `build_branch` and `publish_tag`
  at their test defaults. This exercises the full pin → build → publish path against
  `builds/nightly-test` / `nightly-test` without touching production.
- Confirm the resolver log shows `checking wso2/ballerina-vscode@… for
  extension/resources/jslibs/federation/remoteEntry.js`, and a `rejecting …` line if the rolling
  nightly asset is currently incomplete.
- Confirm `Validate embedded creation form dependencies` passes on both Linux and Windows.
- Confirm `Aligned …/02-create-integration.sh with the current welcome page` appears twice per job.
- Negative check on the route guard: dispatch with `build_branch: builds/nightly` and
  `publish_tag: nightly-test`; the run must fail in `Validate build route`.

## Notes for review

- The resolver now downloads candidate VSIXes during the pin step. In the normal case that is one
  download; the worst case is one per rejected release until a compatible one is found.
- `allow_smoke_test_failures` is **not** part of this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable manual build runs with selectable source refs, build branches, and publishing tags.
  * Added compatibility checks to ensure required extension resources are included in release artifacts.
  * Added support for running smoke tests against a specified source revision.

* **Bug Fixes**
  * Improved Windows dependency setup and recovery when existing checkouts cannot be updated.
  * Updated smoke tests to verify the embedded creation form and align examples with the current welcome page.

* **Chores**
  * Improved nightly build coordination, version selection, and publishing reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->