### PR TITLE
Fix nightly build rolling issue and parameterize the smoke tests for the release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1264,8 +1264,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # `nightly` is a rolling tag and every night's filenames carry a fresh timestamp, so the
-      # upload above adds to the previous night's assets instead of replacing them. They are cleared
+      # A `nightly*` tag is rolling, and every build's filenames carry a fresh timestamp, so the
+      # upload above adds to the previous build's assets instead of replacing them. They are cleared
       # here rather than before the upload: the tag is what external consumers pin their download
       # URLs to, and deleting first would leave it empty — or, if any step in between failed, gone —
       # so a complete set is always downloadable. Everything this build produced is verified present
@@ -1276,14 +1276,26 @@ jobs:
       # tag that does not yet exist, so without this the rolling tag would stay pinned to whichever
       # commit first published it while its assets moved on.
       #
+      # The gate is a prefix match, not `== 'nightly'`, so a `nightly-test` dispatch of
+      # daily-build.yml exercises this exact path — including the delete loop, which is the only part
+      # here that can destroy something — against a disposable tag. Gating on the production tag
+      # alone would make the destructive branch unreachable outside production. It stays false for
+      # the other two callers: release.yml passes `v<version>` and dev-build.yml passes ''.
+      #
+      # PUBLISH_TAG is bound through `env` rather than interpolated into the script for the reason
+      # release.yml spells out: `${{ }}` is expanded before bash parses the body, so a value carrying
+      # shell syntax would change the commands being run rather than the tag they act on.
+      #
       # GH_REPO is required, not belt-and-braces: this job never checks the repository out, so `gh`
-      # has no remote to infer the repository from and every call fails without it.
+      # has no remote to infer the repository from and every call fails without it. That is exactly
+      # what silently disabled the delete-first step this replaces.
       - name: Roll the nightly tag and drop superseded assets
-        if: ${{ inputs.publish_tag == 'nightly' }}
+        if: ${{ startsWith(inputs.publish_tag, 'nightly') }}
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
+          PUBLISH_TAG: ${{ inputs.publish_tag }}
           TARGET_SHA: ${{ inputs.target_commitish != '' && inputs.target_commitish || github.sha }}
         run: |
           set -euo pipefail
@@ -1294,21 +1306,22 @@ jobs:
             echo "Error: no files were published, so there is nothing to supersede." >&2
             exit 1
           fi
-          attached=$(gh release view nightly --json assets --jq '.assets[].name' | sed '/^$/d' | sort)
+          attached=$(gh release view "${PUBLISH_TAG}" --json assets --jq '.assets[].name' \
+            | sed '/^$/d' | sort)
 
           # An upload that silently dropped a file would otherwise be "fixed" by deleting the
           # previous, complete set. Bail out and leave both sets attached instead.
           missing=$(comm -23 <(printf '%s\n' "${published}") <(printf '%s\n' "${attached}"))
           if [ -n "${missing}" ]; then
-            echo "Error: these files did not reach the nightly release:" >&2
+            echo "Error: these files did not reach the ${PUBLISH_TAG} release:" >&2
             printf '  - %s\n' ${missing} >&2
             echo "       Keeping the previous assets; the release still holds a full set." >&2
             exit 1
           fi
 
-          gh api -X PATCH "repos/${GH_REPO}/git/refs/tags/nightly" \
+          gh api -X PATCH "repos/${GH_REPO}/git/refs/tags/${PUBLISH_TAG}" \
             -f sha="${TARGET_SHA}" -F force=true >/dev/null
-          echo "nightly now tags ${TARGET_SHA}."
+          echo "${PUBLISH_TAG} now tags ${TARGET_SHA}."
 
           superseded=$(comm -13 <(printf '%s\n' "${published}") <(printf '%s\n' "${attached}"))
           if [ -z "${superseded}" ]; then
@@ -1316,6 +1329,6 @@ jobs:
             exit 0
           fi
           while IFS= read -r name; do
-            gh release delete-asset nightly "${name}" --yes
+            gh release delete-asset "${PUBLISH_TAG}" "${name}" --yes
             echo "Removed superseded asset ${name}"
           done <<< "${superseded}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,11 @@ on:
         default: true
         required: false
         type: boolean
+      run_smoke_tests:
+        description: 'Whether to run the UI smoke tests. Only takes effect when build_packed_installers is true.'
+        default: true
+        required: false
+        type: boolean
       ballerina_extension_source:
         description: 'Choose whether to bundle Ballerina from GitHub VSIX or use marketplace flow'
         required: false
@@ -222,7 +227,7 @@ jobs:
       ref: ${{ inputs.ref }}
 
   smoke-test:
-    if: ${{ inputs.build_packed_installers == true }}
+    if: ${{ inputs.build_packed_installers == true && inputs.run_smoke_tests == true }}
     needs: compile
     uses: ./.github/workflows/smoke-test.yml
     with:
@@ -232,7 +237,7 @@ jobs:
       ref: ${{ inputs.ref }}
 
   smoke-test-windows:
-    if: ${{ inputs.build_windows == true && inputs.build_packed_installers == true }}
+    if: ${{ inputs.build_windows == true && inputs.build_packed_installers == true && inputs.run_smoke_tests == true }}
     needs: build-windows
     uses: ./.github/workflows/smoke-test.yml
     with:
@@ -1092,14 +1097,16 @@ jobs:
     runs-on: ubuntu-latest
     needs: [resolve-versions, compile, build-macos, build-windows, smoke-test, smoke-test-windows]
     # A published tag is permanent and user-visible, so every platform that was asked for must have
-    # succeeded. `skipped` is allowed because build-macos/build-windows are gated on their own
-    # inputs; a *failed* platform job skips this job, and the run is already red from that failure.
+    # succeeded. `skipped` is allowed for build-macos/build-windows because they are gated on their
+    # own inputs, and for smoke-test/smoke-test-windows because run_smoke_tests can turn them off
+    # deliberately; a *failed* job of any of these skips this job, and the run is already red from
+    # that failure.
     if: |
       always() &&
       (needs.compile.result == 'success') &&
       (needs.build-macos.result == 'success' || needs.build-macos.result == 'skipped') &&
       (needs.build-windows.result == 'success' || needs.build-windows.result == 'skipped') &&
-      (needs.smoke-test.result == 'success') &&
+      (needs.smoke-test.result == 'success' || needs.smoke-test.result == 'skipped') &&
       (needs.smoke-test-windows.result == 'success' || needs.smoke-test-windows.result == 'skipped') &&
       (inputs.publish_tag != '') &&
       (inputs.build_packed_installers == true)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1204,21 +1204,6 @@ jobs:
             echo "name=WSO2 Integrator ${PUBLISH_TAG}" >> "$GITHUB_OUTPUT"
           fi
 
-      # `nightly` is a rolling tag: every night's filenames carry a fresh timestamp, so re-uploading
-      # would let last night's assets pile up. Drop the release and its tag first so it always
-      # reflects exactly one build.
-      - name: Clear the previous nightly release
-        if: ${{ inputs.publish_tag == 'nightly' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if gh release view nightly >/dev/null 2>&1; then
-            gh release delete nightly --yes --cleanup-tag
-            echo "Deleted the previous nightly release and tag."
-          else
-            echo "No existing nightly release to delete."
-          fi
-
       - name: List release files
         env:
           PUBLISH_TAG: ${{ inputs.publish_tag }}
@@ -1278,3 +1263,59 @@ jobs:
           files: release-files/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # `nightly` is a rolling tag and every night's filenames carry a fresh timestamp, so the
+      # upload above adds to the previous night's assets instead of replacing them. They are cleared
+      # here rather than before the upload: the tag is what external consumers pin their download
+      # URLs to, and deleting first would leave it empty — or, if any step in between failed, gone —
+      # so a complete set is always downloadable. Everything this build produced is verified present
+      # before anything is removed, which is also what guarantees the release never ends up with no
+      # assets at all.
+      #
+      # The tag is moved for the same reason it is not deleted: `action-gh-release` only creates a
+      # tag that does not yet exist, so without this the rolling tag would stay pinned to whichever
+      # commit first published it while its assets moved on.
+      #
+      # GH_REPO is required, not belt-and-braces: this job never checks the repository out, so `gh`
+      # has no remote to infer the repository from and every call fails without it.
+      - name: Roll the nightly tag and drop superseded assets
+        if: ${{ inputs.publish_tag == 'nightly' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TARGET_SHA: ${{ inputs.target_commitish != '' && inputs.target_commitish || github.sha }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          published=$(for file in release-files/*; do basename "${file}"; done | sort)
+          if [ -z "${published}" ]; then
+            echo "Error: no files were published, so there is nothing to supersede." >&2
+            exit 1
+          fi
+          attached=$(gh release view nightly --json assets --jq '.assets[].name' | sed '/^$/d' | sort)
+
+          # An upload that silently dropped a file would otherwise be "fixed" by deleting the
+          # previous, complete set. Bail out and leave both sets attached instead.
+          missing=$(comm -23 <(printf '%s\n' "${published}") <(printf '%s\n' "${attached}"))
+          if [ -n "${missing}" ]; then
+            echo "Error: these files did not reach the nightly release:" >&2
+            printf '  - %s\n' ${missing} >&2
+            echo "       Keeping the previous assets; the release still holds a full set." >&2
+            exit 1
+          fi
+
+          gh api -X PATCH "repos/${GH_REPO}/git/refs/tags/nightly" \
+            -f sha="${TARGET_SHA}" -F force=true >/dev/null
+          echo "nightly now tags ${TARGET_SHA}."
+
+          superseded=$(comm -13 <(printf '%s\n' "${published}") <(printf '%s\n' "${attached}"))
+          if [ -z "${superseded}" ]; then
+            echo "No superseded assets to remove."
+            exit 0
+          fi
+          while IFS= read -r name; do
+            gh release delete-asset nightly "${name}" --yes
+            echo "Removed superseded asset ${name}"
+          done <<< "${superseded}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1264,31 +1264,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # A `nightly*` tag is rolling, and every build's filenames carry a fresh timestamp, so the
-      # upload above adds to the previous build's assets instead of replacing them. They are cleared
-      # here rather than before the upload: the tag is what external consumers pin their download
-      # URLs to, and deleting first would leave it empty — or, if any step in between failed, gone —
-      # so a complete set is always downloadable. Everything this build produced is verified present
-      # before anything is removed, which is also what guarantees the release never ends up with no
-      # assets at all.
+      # A `nightly*` tag is rolling: every build's filenames carry a fresh timestamp, so the upload
+      # above adds to the previous build's assets instead of replacing them. This step verifies the
+      # new set fully landed, moves the tag to the current commit (action-gh-release only creates a
+      # tag that doesn't yet exist), then removes the superseded assets — in that order, so the
+      # release is never left incomplete or empty.
       #
-      # The tag is moved for the same reason it is not deleted: `action-gh-release` only creates a
-      # tag that does not yet exist, so without this the rolling tag would stay pinned to whichever
-      # commit first published it while its assets moved on.
+      # The gate is a prefix match, not `== 'nightly'`, so a disposable `nightly-test` dispatch can
+      # exercise the delete loop without touching the production tag. It stays false for the other
+      # two callers: release.yml passes `v<version>` and dev-build.yml passes ''.
       #
-      # The gate is a prefix match, not `== 'nightly'`, so a `nightly-test` dispatch of
-      # daily-build.yml exercises this exact path — including the delete loop, which is the only part
-      # here that can destroy something — against a disposable tag. Gating on the production tag
-      # alone would make the destructive branch unreachable outside production. It stays false for
-      # the other two callers: release.yml passes `v<version>` and dev-build.yml passes ''.
-      #
-      # PUBLISH_TAG is bound through `env` rather than interpolated into the script for the reason
-      # release.yml spells out: `${{ }}` is expanded before bash parses the body, so a value carrying
-      # shell syntax would change the commands being run rather than the tag they act on.
-      #
-      # GH_REPO is required, not belt-and-braces: this job never checks the repository out, so `gh`
-      # has no remote to infer the repository from and every call fails without it. That is exactly
-      # what silently disabled the delete-first step this replaces.
+      # PUBLISH_TAG is bound through `env`, not interpolated directly, so a tag value containing
+      # shell syntax can't change the commands being run.
       - name: Roll the nightly tag and drop superseded assets
         if: ${{ startsWith(inputs.publish_tag, 'nightly') }}
         shell: bash
@@ -1314,7 +1301,9 @@ jobs:
           missing=$(comm -23 <(printf '%s\n' "${published}") <(printf '%s\n' "${attached}"))
           if [ -n "${missing}" ]; then
             echo "Error: these files did not reach the ${PUBLISH_TAG} release:" >&2
-            printf '  - %s\n' ${missing} >&2
+            while IFS= read -r name; do
+              echo "  - ${name}" >&2
+            done <<< "${missing}"
             echo "       Keeping the previous assets; the release still holds a full set." >&2
             exit 1
           fi

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -44,6 +44,11 @@ on:
         required: true
         type: string
         default: nightly-test
+      run_smoke_tests:
+        description: 'Whether to run the UI smoke tests. Ignored on the scheduled production run, which always runs them.'
+        required: true
+        type: boolean
+        default: true
 
 permissions:
   id-token: write
@@ -220,5 +225,8 @@ jobs:
       build_macos: true
       build_windows: true
       build_packed_installers: true
+      # Ignore the dispatch input on a scheduled run, same as the route env vars above: the
+      # production nightly always exercises the smoke tests.
+      run_smoke_tests: ${{ github.event_name == 'schedule' && true || inputs.run_smoke_tests }}
       ballerina_extension_source: github
       mi_extension_source: github

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -39,6 +39,11 @@ on:
         required: true
         default: true
         type: boolean
+      run_smoke_tests:
+        description: 'Whether to run the UI smoke tests. Only takes effect when build_packed_installers is true.'
+        required: true
+        default: true
+        type: boolean
       ballerina_extension_source:
         description: 'Choose whether to bundle Ballerina from GitHub VSIX or use marketplace flow'
         required: true
@@ -82,5 +87,6 @@ jobs:
       build_macos: ${{ inputs.build_macos }}
       build_windows: ${{ inputs.build_windows }}
       build_packed_installers: ${{ inputs.build_packed_installers }}
+      run_smoke_tests: ${{ inputs.run_smoke_tests }}
       ballerina_extension_source: ${{ inputs.ballerina_extension_source }}
       mi_extension_source: ${{ inputs.mi_extension_source }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,11 @@ on:
         required: true
         default: true
         type: boolean
+      run_smoke_tests:
+        description: 'Whether to run the UI smoke tests. Only takes effect when build_packed_installers is true.'
+        required: true
+        default: true
+        type: boolean
       ballerina_extension_source:
         description: 'Choose whether to bundle Ballerina from GitHub VSIX or use marketplace flow'
         required: true
@@ -198,5 +203,6 @@ jobs:
       build_macos: ${{ inputs.build_macos }}
       build_windows: ${{ inputs.build_windows }}
       build_packed_installers: ${{ inputs.build_packed_installers }}
+      run_smoke_tests: ${{ inputs.run_smoke_tests }}
       ballerina_extension_source: ${{ inputs.ballerina_extension_source }}
       mi_extension_source: ${{ inputs.mi_extension_source }}


### PR DESCRIPTION
## Purpose
$Subject; currently nightly tag is not overridden but it currently it pushes the new nightly build and since it has a new timestamp it is not overriding but it put it under the same tag

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nightly release publishing reliability by verifying uploaded assets before updating the release.
  * Preserved the previous nightly release when publication is incomplete, reducing disruption from partial uploads.
  * Ensured nightly release tags point to the intended changes after successful publication.
  * Removed only superseded assets after successful publication while retaining valid existing assets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->