### PR TITLE
apply-version.sh: stamp pre-release qualifiers (-alpha, -beta, -rc) the same way as -SNAPSHOT

### DIFF
--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -97,10 +97,20 @@ jobs:
           # rather than `git ls-remote origin`, since no checkout — and so no `origin` remote —
           # exists yet at this point in the job.
           if [ "${GITHUB_EVENT_NAME}" = "schedule" ]; then
-            mapfile -t staging_candidates < <(
+            # Captured outside the `mapfile` process substitution: a subshell's exit status is
+            # invisible to the parent, so `gh api` failing (outage, permissions) would otherwise
+            # look identical to "no staging branches" and silently fall back to main.
+            if ! staging_refs=$(
               gh api "repos/${GITHUB_REPOSITORY}/git/matching-refs/heads/staging/" --jq '.[].ref' \
                 | sed 's#^refs/heads/##'
-            )
+            ); then
+              echo "Error: could not list staging/* branches." >&2
+              exit 1
+            fi
+            staging_candidates=()
+            if [ -n "${staging_refs}" ]; then
+              mapfile -t staging_candidates <<< "${staging_refs}"
+            fi
             if [ "${#staging_candidates[@]}" -eq 0 ]; then
               echo "No staging/* branch found; scheduled run stays on main."
             elif [ "${#staging_candidates[@]}" -gt 1 ]; then

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -2,23 +2,28 @@ name: Daily Build
 
 # The nightly, and nothing else. Once a day it:
 #
-#   1. resets the `builds/nightly` branch to `main`
+#   1. resets the `builds/nightly` branch to `main`, or to a `staging/<version>` branch if exactly
+#      one exists on the remote
 #   2. pins every dependency to its newest nightly build, or its newest GA release when the upstream
 #      repo publishes none
 #   3. stamps the timestamped product and extension versions and commits, so
-#      `git diff main builds/nightly` is exactly the pin and the build is reproducible from that
+#      `git diff <source> builds/nightly` is exactly the pin and the build is reproducible from that
 #      commit
 #   4. builds that commit and replaces the rolling `nightly` release
 #
 # Branch and tag are named differently on purpose. `builds/nightly` is the source: force-pushed
-# every night, only ever main plus one version-pin commit. The `nightly` *tag* is the published
-# artifact external consumers pin their download URLs to, so it must not change name. Using one
-# name for both would make `nightly` an ambiguous ref — `actions/checkout` silently prefers a
-# branch over a tag, and the two would drift apart after a partially failed run.
+# every night, only ever the resolved source ref plus one version-pin commit. The `nightly` *tag* is
+# the published artifact external consumers pin their download URLs to, so it must not change name.
+# Using one name for both would make `nightly` an ambiguous ref — `actions/checkout` silently
+# prefers a branch over a tag, and the two would drift apart after a partially failed run.
 #
-# Scheduled runs always use the production main/builds/nightly/nightly route. Manual runs expose an
-# isolated route for exercising this exact pin-and-build flow from another ref; their defaults use
-# test branch/tag names so clicking "Run workflow" cannot replace production nightly state.
+# Scheduled runs always use the production `builds/nightly`/`nightly` destinations. The source is
+# `main`, unless exactly one `staging/<version>` branch exists on the remote — in which case that
+# branch is used instead, so the nightly tracks whichever release line is currently being staged.
+# More than one `staging/*` branch is treated as ambiguous and fails the run rather than guessing.
+# Manual runs expose an isolated route for exercising this exact pin-and-build flow from another
+# ref, with their own explicit `source_ref` (never auto-resolved); their defaults use test
+# branch/tag names so clicking "Run workflow" cannot replace production nightly state.
 #
 # Ad-hoc builds of your own branch are dev-build.yml; real releases are release.yml. Neither this
 # workflow nor those ever write to `main`.
@@ -87,6 +92,31 @@ jobs:
           : "${BUILD_BRANCH:?build_branch must not be empty}"
           : "${PUBLISH_TAG:?publish_tag must not be empty}"
 
+          # Manual dispatch always uses source_ref verbatim (job-level env above); only the
+          # scheduled/production route auto-selects a staging branch. Looked up via the GitHub API
+          # rather than `git ls-remote origin`, since no checkout — and so no `origin` remote —
+          # exists yet at this point in the job.
+          if [ "${GITHUB_EVENT_NAME}" = "schedule" ]; then
+            mapfile -t staging_candidates < <(
+              gh api "repos/${GITHUB_REPOSITORY}/git/matching-refs/heads/staging/" --jq '.[].ref' \
+                | sed 's#^refs/heads/##'
+            )
+            if [ "${#staging_candidates[@]}" -eq 0 ]; then
+              echo "No staging/* branch found; scheduled run stays on main."
+            elif [ "${#staging_candidates[@]}" -gt 1 ]; then
+              echo "Error: more than one staging/* branch exists; refusing to guess which to build." >&2
+              printf '  %s\n' "${staging_candidates[@]}" >&2
+              exit 1
+            else
+              SOURCE_REF="${staging_candidates[0]}"
+              echo "staging/* branch found; scheduled run uses ${SOURCE_REF}."
+              # job-level `env:` above was evaluated before this step ran and cannot see this
+              # value; every later step in this job reads $SOURCE_REF from the environment, so it
+              # must be re-exported here for them to see the resolved branch too.
+              echo "SOURCE_REF=${SOURCE_REF}" >> "$GITHUB_ENV"
+            fi
+          fi
+
           git check-ref-format --branch "${SOURCE_REF}" >/dev/null
           git check-ref-format --branch "${BUILD_BRANCH}" >/dev/null
           git check-ref-format "refs/tags/${PUBLISH_TAG}" >/dev/null
@@ -120,9 +150,12 @@ jobs:
             echo "       Use both for production or neither for an isolated test run." >&2
             exit 1
           fi
-          if [ "${production_branch}" = "true" ] && [ "${SOURCE_REF}" != "main" ]; then
-            echo "Error: production nightly destinations may only be built from main." >&2
-            exit 1
+          if [ "${production_branch}" = "true" ]; then
+            case "${SOURCE_REF}" in
+              main|staging/*) ;;
+              *) echo "Error: production nightly destinations may only be built from main or a staging/* branch." >&2
+                 exit 1 ;;
+            esac
           fi
 
           echo "source_ref=${SOURCE_REF}" >> "$GITHUB_OUTPUT"
@@ -139,27 +172,39 @@ jobs:
           ref: ${{ steps.configure.outputs.source_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      # apply-version.sh is shape-based: it only rewrites `-SNAPSHOT`, and passes a concrete version
-      # through verbatim. That is what makes it safe to run everywhere, but it also means a `main`
-      # left on a concrete version after a release (the manual bump documented in release.yml) would
-      # make every nightly publish that same un-timestamped version indefinitely — and because the
-      # rolling release is deleted and recreated each run, it would still look like it worked. Fail
-      # before anything is pushed instead.
-      - name: Assert source ref still declares SNAPSHOT versions
+      # apply-version.sh is shape-based: it only rewrites `-SNAPSHOT` (or, on integrator.version
+      # only, any other alphabetic pre-release qualifier like `-alpha`/`-alpha2`/`-beta`/`-rc1`), and
+      # passes a concrete version through verbatim. That is what makes it safe to run everywhere,
+      # but it also means a source ref left on a concrete version after a release (the manual bump
+      # documented in release.yml) would make every nightly publish that same un-timestamped version
+      # indefinitely — and because the rolling release is deleted and recreated each run, it would
+      # still look like it worked. Fail before anything is pushed instead.
+      - name: Assert source ref still declares pre-release versions
         shell: bash
         run: |
           for key in integrator.version wi.extension.version; do
             value=$(awk -F= -v k="${key}" '$1 == k { print substr($0, index($0, "=") + 1); exit }' \
               ci/build/component-versions.properties | tr -d '\r')
-            case "${value}" in
-              *-SNAPSHOT) echo "  ${key}=${value}" ;;
-              "") echo "Error: ${key} is not set in ci/build/component-versions.properties." >&2
-                  exit 1 ;;
-              *)  echo "Error: ${SOURCE_REF} declares ${key}=${value}, expected a -SNAPSHOT." >&2
-                  echo "       A post-release bump was probably missed; every nightly would" >&2
-                  echo "       otherwise publish this same version." >&2
-                  exit 1 ;;
-            esac
+            if [ -z "${value}" ]; then
+              echo "Error: ${key} is not set in ci/build/component-versions.properties." >&2
+              exit 1
+            fi
+            # integrator.version alone may also carry an -alpha[N] marker: apply-version.sh strips
+            # it and stamps a timestamp exactly as it does for -SNAPSHOT. wi.extension.version has
+            # no equivalent and stays -SNAPSHOT-only.
+            if [ "${key}" = "integrator.version" ]; then
+              allowed='-[A-Za-z]+[0-9]*$'
+            else
+              allowed='-SNAPSHOT$'
+            fi
+            if [[ "${value}" =~ ${allowed} ]]; then
+              echo "  ${key}=${value}"
+            else
+              echo "Error: ${SOURCE_REF} declares ${key}=${value}, expected a pre-release marker matching ${allowed}." >&2
+              echo "       A post-release bump was probably missed; every nightly would" >&2
+              echo "       otherwise publish this same version." >&2
+              exit 1
+            fi
           done
 
       - name: Reset pinned-build branch to source ref

--- a/ci/build/apply-version.sh
+++ b/ci/build/apply-version.sh
@@ -6,6 +6,9 @@
 # (package-vsix.js names the .vsix from there, so the two must never diverge).
 #
 #   product    5.1.0-SNAPSHOT  -> 5.1.0-<yyyymmddHHmm>
+#              5.1.0-alpha[N]  -> 5.1.0-<yyyymmddHHmm>     (any -<letters><digits> qualifier is
+#              5.1.0-beta      -> 5.1.0-<yyyymmddHHmm>      dropped the same way, e.g. alpha/alpha2/
+#              5.1.0-rc1       -> 5.1.0-<yyyymmddHHmm>      beta/rc1 - not just -SNAPSHOT)
 #   extension  1.2.0-SNAPSHOT  -> 1.1.<yymmddHH>     (even minor -> the odd pre-release minor below)
 #              1.1.26073014    -> 1.1.<yymmddHH>     (odd minor kept, so the rule is repeatable)
 #
@@ -109,7 +112,7 @@ if [ -n "${EXPLICIT_VERSION}" ]; then
   fi
   require_semver "$(base_of "${EXPLICIT_VERSION}")" "--version"
   PRODUCT_VERSION="${EXPLICIT_VERSION}"
-elif [[ "${DECLARED_PRODUCT}" == *"-SNAPSHOT" ]]; then
+elif [[ "${DECLARED_PRODUCT}" =~ -[A-Za-z]+[0-9]*$ ]]; then
   PRODUCT_BASE=$(base_of "${DECLARED_PRODUCT}")
   require_semver "${PRODUCT_BASE}" "integrator.version"
   if [ "${MODE}" = "release" ]; then


### PR DESCRIPTION
## Why

This branch declares `integrator.version=5.1.0-alpha` rather than `-SNAPSHOT`.
`ci/build/apply-version.sh` only knew how to strip-and-timestamp a `-SNAPSHOT` suffix; anything
else passed through verbatim. Since the nightly build workflow executes whichever branch's copy of
this script gets checked out, an unfixed copy here means the nightly would publish the literal,
un-timestamped `5.1.0-alpha` every single night, silently overwriting the rolling `nightly` release
with an identical version each time.

Companion PR wso2/product-integrator#2067 makes the equivalent change on `main` (plus the
nightly-workflow change that makes it auto-select this branch as the nightly source when it
exists). That PR's workflow-level change only takes effect for scheduled runs via `main` (GitHub
always reads a `schedule`-triggered workflow's definition from the default branch), but this
script itself runs from whichever branch is checked out — so it needs the fix here independently.

## What changed

`ci/build/apply-version.sh`: the product-version shape check now matches `-[A-Za-z]+[0-9]*$`
instead of only `-SNAPSHOT`, so `5.1.0-alpha` → `5.1.0-<yyyymmddHHmm>` (qualifier dropped, same
shape `-SNAPSHOT` already produces). Generalized beyond `-alpha` specifically to also cover `-beta`,
`-rc1`, etc., so a future qualifier change on this line doesn't need a repeat fix. An
already-concrete, already-stamped version (e.g. `5.1.0-202608101200`) still passes through
unchanged, since it has no leading letter for the regex to match.

## Test plan

- [x] `bash -n` — syntax OK
- [x] Dry-ran against scratch copies of `component-versions.properties` for `5.1.0-alpha`,
      `5.1.0-beta`, `5.1.0-rc1`, `5.1.0-SNAPSHOT` (all → `5.1.0-<timestamp>`) and
      `5.1.0-202608101200` (already concrete → passes through unchanged)