### PR TITLE
Agent Builder mode UX follow-ups

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,28 @@
 			],
 			"env": {
 				"WEB_VIEW_DEV_MODE": "true",
+				"WEB_VIEW_DEV_HOST": "http://localhost:3000"
+			},
+			"outFiles": [
+				"${workspaceFolder}/wi/wi-extension/dist/**/*.js"
+			],
+			"preLaunchTask": "Watch WI extension"
+		},
+		{
+			// Same as "Run WI Extension" but launches in the WSO2 Agent Builder
+			// flavor. Agent Builder is an opt-in mode: every default (this
+			// extension, update-product.sh, CI inputs) stays 'integrator'.
+			"name": "Run WI Extension (Agent Builder)",
+			"type": "extensionHost",
+			"request": "launch",
+			"args": [
+				"--extensionDevelopmentPath=${workspaceFolder}/wi/wi-extension",
+			],
+			"env": {
+				"WEB_VIEW_DEV_MODE": "true",
 				"WEB_VIEW_DEV_HOST": "http://localhost:3000",
+				"WSO2_PRODUCT_MODE": "agent-builder",
+				"WSO2_PRODUCT_NAME": "WSO2 Agent Builder"
 			},
 			"outFiles": [
 				"${workspaceFolder}/wi/wi-extension/dist/**/*.js"

--- a/wi/wi-core/src/constants.ts
+++ b/wi/wi-core/src/constants.ts
@@ -59,6 +59,9 @@ export const COMMANDS = {
  */
 export const VIEWS = {
 	INTEGRATOR_EXPLORER: "wso2-integrator.explorer",
+	// Same explorer tree, contributed under the Agent Builder activity-bar
+	// container so the icon/title match the product flavor.
+	AGENT_BUILDER_EXPLORER: "wso2-agent-builder.explorer",
 };
 
 /**

--- a/wi/wi-extension/package.json
+++ b/wi/wi-extension/package.json
@@ -115,6 +115,11 @@
           "id": "wso2-integrator",
           "title": "WSO2 Integrator",
           "icon": "resources/icons/integrator-activity-icon.svg"
+        },
+        {
+          "id": "wso2-agent-builder",
+          "title": "WSO2 Agent Builder",
+          "icon": "resources/icons/integrator-activity-icon.svg"
         }
       ]
     },
@@ -124,7 +129,15 @@
           "id": "wso2-integrator.explorer",
           "name": "Integrations",
           "contextualTitle": "WSO2 Integrator",
-          "when": "!WI.projectType || (WI.projectType != 'si' && WI.projectType != 'mi')"
+          "when": "WI.productMode != 'agent-builder' && (!WI.projectType || (WI.projectType != 'si' && WI.projectType != 'mi'))"
+        }
+      ],
+      "wso2-agent-builder": [
+        {
+          "id": "wso2-agent-builder.explorer",
+          "name": "Agents",
+          "contextualTitle": "WSO2 Agent Builder",
+          "when": "WI.productMode == 'agent-builder' && (!WI.projectType || (WI.projectType != 'si' && WI.projectType != 'mi'))"
         }
       ]
     },
@@ -135,7 +148,7 @@
         "when": "WI.productMode != 'agent-builder' && !WI.projectType && BI.status != 'updateNeed' && BI.status != 'noLS'"
       },
       {
-        "view": "wso2-integrator.explorer",
+        "view": "wso2-agent-builder.explorer",
         "contents": "$(loadingspin) Loading WSO2 Agent Builder...",
         "when": "WI.productMode == 'agent-builder' && !WI.projectType && BI.status != 'updateNeed' && BI.status != 'noLS'"
       },
@@ -145,7 +158,7 @@
         "when": "WI.productMode != 'agent-builder' && WI.projectType == 'none'"
       },
       {
-        "view": "wso2-integrator.explorer",
+        "view": "wso2-agent-builder.explorer",
         "contents": "$(rocket) Build AI agents with WSO2 Agent Builder.\n\nUse the welcome page to create a new agent project or explore samples.\n\nOpen an agent project folder to see your artifacts in this panel.\n\n[Get Started](command:wso2.integrator.openWelcome)",
         "when": "WI.productMode == 'agent-builder' && WI.projectType == 'none'"
       },
@@ -155,12 +168,17 @@
         "when": "BI.project.empty"
       },
       {
+        "view": "wso2-agent-builder.explorer",
+        "contents": "No integrations or libraries found in this project.\n\nGet started by adding your first integration or library.\n\n[$(add) Add Integration or Library](command:BI.project-explorer.add)",
+        "when": "BI.project.empty"
+      },
+      {
         "view": "wso2-integrator.explorer",
         "contents": "Welcome to WSO2 Integrator.\n\nYour current Ballerina distribution is not supported. Please update to version 2201.12.3 or above to continue.\n\n[Update Ballerina](command:wso2.integrator.setupBallerinaVisually)\n\nAfter updating, restart the editor to apply the changes. [Learn more](https://wso2.com/integration-platform/docs/)",
         "when": "WI.productMode != 'agent-builder' && (!WI.projectType || (WI.projectType != 'si' && WI.projectType != 'mi' && WI.projectType != 'none')) && BI.status == 'updateNeed'"
       },
       {
-        "view": "wso2-integrator.explorer",
+        "view": "wso2-agent-builder.explorer",
         "contents": "Welcome to WSO2 Agent Builder.\n\nYour current Ballerina distribution is not supported. Please update to version 2201.12.3 or above to continue.\n\n[Update Ballerina](command:wso2.integrator.setupBallerinaVisually)\n\nAfter updating, restart the editor to apply the changes. [Learn more](https://wso2.com/integration-platform/docs/)",
         "when": "WI.productMode == 'agent-builder' && (!WI.projectType || (WI.projectType != 'si' && WI.projectType != 'mi' && WI.projectType != 'none')) && BI.status == 'updateNeed'"
       },
@@ -170,7 +188,7 @@
         "when": "WI.productMode != 'agent-builder' && (!WI.projectType || (WI.projectType != 'si' && WI.projectType != 'mi' && WI.projectType != 'none')) && BI.status == 'noLS'"
       },
       {
-        "view": "wso2-integrator.explorer",
+        "view": "wso2-agent-builder.explorer",
         "contents": "Welcome to WSO2 Agent Builder.\n\nA Ballerina distribution is required but was not found on this machine. Please set up Ballerina to get started.\n\n[Set Up Ballerina](command:wso2.integrator.setupBallerinaVisually)\n\nAfter installation, restart the editor to apply the changes. [Learn more](https://wso2.com/integration-platform/docs/)",
         "when": "WI.productMode == 'agent-builder' && (!WI.projectType || (WI.projectType != 'si' && WI.projectType != 'mi' && WI.projectType != 'none')) && BI.status == 'noLS'"
       }
@@ -512,134 +530,134 @@
       "view/item/context": [
         {
           "command": "ballerina.showVisualizer",
-          "when": "view == wso2-integrator.explorer && viewItem == bi-project",
+          "when": "(view == wso2-integrator.explorer || view == wso2-agent-builder.explorer) && viewItem == bi-project",
           "group": "inline"
         },
         {
           "command": "ballerina.force.update.artifacts",
-          "when": "view == wso2-integrator.explorer && viewItem == bi-project",
+          "when": "(view == wso2-integrator.explorer || view == wso2-agent-builder.explorer) && viewItem == bi-project",
           "group": "inline"
         },
         {
           "command": "BI.project-explorer.convert",
-          "when": "view == wso2-integrator.explorer && viewItem == bi-project && BI.isBallerinaWorkspace != true && BI.enclosingProjectStatus != 'member' && BI.enclosingProjectStatus != 'orphaned'",
+          "when": "(view == wso2-integrator.explorer || view == wso2-agent-builder.explorer) && viewItem == bi-project && BI.isBallerinaWorkspace != true && BI.enclosingProjectStatus != 'member' && BI.enclosingProjectStatus != 'orphaned'",
           "group": "navigation"
         },
         {
           "command": "BI.project-explorer.open-project",
-          "when": "view == wso2-integrator.explorer && viewItem == bi-project && BI.isBallerinaWorkspace != true && BI.enclosingProjectStatus == 'member'",
+          "when": "(view == wso2-integrator.explorer || view == wso2-agent-builder.explorer) && viewItem == bi-project && BI.isBallerinaWorkspace != true && BI.enclosingProjectStatus == 'member'",
           "group": "navigation"
         },
         {
           "command": "BI.project-explorer.add-to-project",
-          "when": "view == wso2-integrator.explorer && viewItem == bi-project && BI.isBallerinaWorkspace != true && BI.enclosingProjectStatus == 'orphaned'",
+          "when": "(view == wso2-integrator.explorer || view == wso2-agent-builder.explorer) && viewItem == bi-project && BI.isBallerinaWorkspace != true && BI.enclosingProjectStatus == 'orphaned'",
           "group": "navigation"
         },
         {
           "command": "BI.project-explorer.add-connection",
-          "when": "view == wso2-integrator.explorer && viewItem == connections",
+          "when": "(view == wso2-integrator.explorer || view == wso2-agent-builder.explorer) && viewItem == connections",
           "group": "inline"
         },
         {
           "command": "BI.project-explorer.add-agent",
-          "when": "view == wso2-integrator.explorer && viewItem == agents",
+          "when": "(view == wso2-integrator.explorer || view == wso2-agent-builder.explorer) && viewItem == agents",
           "group": "inline"
         },
         {
           "command": "BI.project-explorer.add-agent-definition",
-          "when": "view == wso2-integrator.explorer && viewItem == agentDefinitions",
+          "when": "(view == wso2-integrator.explorer || view == wso2-agent-builder.explorer) && viewItem == agentDefinitions",
           "group": "inline"
         },
         {
           "command": "BI.project-explorer.delete",
-          "when": "view == wso2-integrator.explorer && (viewItem == CONNECTION || viewItem == SERVICE || viewItem == FUNCTION || viewItem == AUTOMATION || viewItem == TYPE || viewItem == CONFIGURABLE || viewItem == DATA_MAPPER || viewItem == NP_FUNCTION || viewItem == localConnector || viewItem == WORKFLOW || viewItem == ACTIVITY || viewItem == AGENT || viewItem == AGENT_DEFINITION)",
+          "when": "(view == wso2-integrator.explorer || view == wso2-agent-builder.explorer) && (viewItem == CONNECTION || viewItem == SERVICE || viewItem == FUNCTION || viewItem == AUTOMATION || viewItem == TYPE || viewItem == CONFIGURABLE || viewItem == DATA_MAPPER || viewItem == NP_FUNCTION || viewItem == localConnector || viewItem == WORKFLOW || viewItem == ACTIVITY || viewItem == AGENT || viewItem == AGENT_DEFINITION)",
           "group": "inline"
         },
         {
           "command": "BI.project-explorer.add-entry-point",
-          "when": "view == wso2-integrator.explorer && viewItem == entryPoint",
+          "when": "(view == wso2-integrator.explorer || view == wso2-agent-builder.explorer) && viewItem == entryPoint",
           "group": "inline"
         },
         {
           "command": "BI.project-explorer.add-type",
-          "when": "view == wso2-integrator.explorer && viewItem == types",
+          "when": "(view == wso2-integrator.explorer || view == wso2-agent-builder.explorer) && viewItem == types",
           "group": "inline"
         },
         {
           "command": "BI.project-explorer.view-type-diagram",
-          "when": "view == wso2-integrator.explorer && viewItem == types",
+          "when": "(view == wso2-integrator.explorer || view == wso2-agent-builder.explorer) && viewItem == types",
           "group": "inline"
         },
         {
           "command": "BI.project-explorer.add-function",
-          "when": "view == wso2-integrator.explorer && viewItem == functions",
+          "when": "(view == wso2-integrator.explorer || view == wso2-agent-builder.explorer) && viewItem == functions",
           "group": "inline"
         },
         {
           "command": "BI.project-explorer.add-configuration",
-          "when": "view == wso2-integrator.explorer && viewItem == configurations",
+          "when": "(view == wso2-integrator.explorer || view == wso2-agent-builder.explorer) && viewItem == configurations",
           "group": "inline"
         },
         {
           "command": "BI.project-explorer.view-configuration",
-          "when": "view == wso2-integrator.explorer && viewItem == configurations",
+          "when": "(view == wso2-integrator.explorer || view == wso2-agent-builder.explorer) && viewItem == configurations",
           "group": "inline"
         },
         {
           "command": "BI.project-explorer.add-data-mapper",
-          "when": "view == wso2-integrator.explorer && viewItem == dataMappers",
+          "when": "(view == wso2-integrator.explorer || view == wso2-agent-builder.explorer) && viewItem == dataMappers",
           "group": "inline"
         },
         {
           "command": "BI.project-explorer.add-natural-function",
-          "when": "view == wso2-integrator.explorer && viewItem == naturalFunctions",
+          "when": "(view == wso2-integrator.explorer || view == wso2-agent-builder.explorer) && viewItem == naturalFunctions",
           "group": "inline"
         },
         {
           "command": "BI.project-explorer.add-custom-connector",
-          "when": "view == wso2-integrator.explorer && viewItem == localConnectors",
+          "when": "(view == wso2-integrator.explorer || view == wso2-agent-builder.explorer) && viewItem == localConnectors",
           "group": "inline"
         },
         {
           "command": "BI.project-explorer.add-workflow",
-          "when": "view == wso2-integrator.explorer && viewItem == workflows",
+          "when": "(view == wso2-integrator.explorer || view == wso2-agent-builder.explorer) && viewItem == workflows",
           "group": "inline"
         },
         {
           "command": "BI.project-explorer.add-workflow-activity",
-          "when": "view == wso2-integrator.explorer && viewItem == workflowActivities",
+          "when": "(view == wso2-integrator.explorer || view == wso2-agent-builder.explorer) && viewItem == workflowActivities",
           "group": "inline"
         }
       ],
       "view/title": [
         {
           "command": "wso2-integrator.explorer.refresh",
-          "when": "view == wso2-integrator.explorer",
+          "when": "(view == wso2-integrator.explorer || view == wso2-agent-builder.explorer)",
           "group": "navigation@2"
         },
         {
           "command": "BI.project-explorer.convert",
-          "when": "view == wso2-integrator.explorer && BI.project == true && BI.isBallerinaWorkspace != true && BI.enclosingProjectStatus != 'member' && BI.enclosingProjectStatus != 'orphaned'",
+          "when": "(view == wso2-integrator.explorer || view == wso2-agent-builder.explorer) && BI.project == true && BI.isBallerinaWorkspace != true && BI.enclosingProjectStatus != 'member' && BI.enclosingProjectStatus != 'orphaned'",
           "group": "navigation"
         },
         {
           "command": "BI.project-explorer.open-project",
-          "when": "view == wso2-integrator.explorer && BI.project == true && BI.isBallerinaWorkspace != true && BI.enclosingProjectStatus == 'member'",
+          "when": "(view == wso2-integrator.explorer || view == wso2-agent-builder.explorer) && BI.project == true && BI.isBallerinaWorkspace != true && BI.enclosingProjectStatus == 'member'",
           "group": "navigation"
         },
         {
           "command": "BI.project-explorer.add-to-project",
-          "when": "view == wso2-integrator.explorer && BI.project == true && BI.isBallerinaWorkspace != true && BI.enclosingProjectStatus == 'orphaned'",
+          "when": "(view == wso2-integrator.explorer || view == wso2-agent-builder.explorer) && BI.project == true && BI.isBallerinaWorkspace != true && BI.enclosingProjectStatus == 'orphaned'",
           "group": "navigation"
         },
         {
           "command": "BI.project-explorer.add",
-          "when": "view == wso2-integrator.explorer && BI.isBallerinaWorkspace == true",
+          "when": "(view == wso2-integrator.explorer || view == wso2-agent-builder.explorer) && BI.isBallerinaWorkspace == true",
           "group": "navigation"
         },
         {
           "command": "BI.project-explorer.overview",
-          "when": "view == wso2-integrator.explorer && BI.project == true",
+          "when": "(view == wso2-integrator.explorer || view == wso2-agent-builder.explorer) && BI.project == true",
           "group": "navigation"
         }
       ]

--- a/wi/wi-extension/src/bi/project-explorer/activate.ts
+++ b/wi/wi-extension/src/bi/project-explorer/activate.ts
@@ -23,7 +23,9 @@ import { ballerinaContext } from '../ballerinaContext';
 import { COMMANDS, ViewType } from '@wso2/wi-core';
 import { StateMachine } from '../../stateMachine';
 
-const WI_PROJECT_EXPLORER_VIEW_ID = 'wso2-integrator.explorer';
+import { getExplorerViewId } from '../../productMode';
+
+const WI_PROJECT_EXPLORER_VIEW_ID = getExplorerViewId();
 
 export interface ExplorerActivationConfig {
     context: ExtensionContext;

--- a/wi/wi-extension/src/bi/project-explorer/project-explorer-provider.ts
+++ b/wi/wi-extension/src/bi/project-explorer/project-explorer-provider.ts
@@ -34,8 +34,10 @@ import { ballerinaContext } from '../ballerinaContext';
 import { ext } from '../../extensionVariables';
 import { isSamePath } from '../../utils/pathUtils';
 
+import { getExplorerViewId } from '../../productMode';
+
 // View ID used for progress indicator
-const EXPLORER_VIEW_ID = 'wso2-integrator.explorer';
+const EXPLORER_VIEW_ID = getExplorerViewId();
 
 export class ProjectExplorerEntry extends vscode.TreeItem {
     children: ProjectExplorerEntry[] | undefined;

--- a/wi/wi-extension/src/commands.ts
+++ b/wi/wi-extension/src/commands.ts
@@ -23,6 +23,7 @@ import { ext } from "./extensionVariables";
 import { WebviewManager } from "./webviewManager";
 import { ExtensionAPIs } from "./extensionAPIs";
 import { StateMachine, getBIProjectExplorerProvider } from "./stateMachine";
+import { isAgentBuilderMode } from "./productMode";
 import { BridgeLayer } from "./BridgeLayer";
 import type { DownloadProgress } from "@wso2/wi-core";
 
@@ -38,7 +39,7 @@ export function registerCommands(
 	context.subscriptions.push(
 		vscode.commands.registerCommand(COMMANDS.OPEN_WELCOME, () => {
 			try {
-				StateMachine.openWebview(ViewType.WELCOME);
+				StateMachine.openWebview(isAgentBuilderMode() ? ViewType.AGENT_BUILDER_WELCOME : ViewType.WELCOME);
 			} catch (error) {
 				ext.logError("Failed to open welcome page", error as Error);
 				vscode.window.showErrorMessage("Failed to open welcome page");

--- a/wi/wi-extension/src/extension.ts
+++ b/wi/wi-extension/src/extension.ts
@@ -123,6 +123,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Extens
 		// set runtime to context
 		await vscode.commands.executeCommand('setContext', 'WI.isWiRuntime', process.env.WSO2_INTEGRATOR_RUNTIME === 'true');
 		await vscode.commands.executeCommand('setContext', 'WI.productMode', getProductMode());
+		ext.log(`Product mode: ${getProductMode()} (display name: ${getProductName()})`);
 		const productUpdateService = new ProductUpdateServiceClient(context);
 
 		registerEmbeddedWelcomeBootstrapCommand(context);

--- a/wi/wi-extension/src/productMode.ts
+++ b/wi/wi-extension/src/productMode.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { ProductMode, PRODUCT_NAMES } from "@wso2/wi-core";
+import { ProductMode, PRODUCT_NAMES, VIEWS } from "@wso2/wi-core";
 
 /**
  * Resolves the product flavor this extension is running inside.
@@ -43,4 +43,13 @@ export function isAgentBuilderMode(): boolean {
  */
 export function getProductName(): string {
 	return process.env.WSO2_PRODUCT_NAME || PRODUCT_NAMES[getProductMode()];
+}
+
+/**
+ * The project explorer tree is contributed twice — once per activity-bar
+ * container — so each flavor's icon carries its own title. Only the active
+ * flavor's view is visible (`when` clauses on WI.productMode).
+ */
+export function getExplorerViewId(): string {
+	return isAgentBuilderMode() ? VIEWS.AGENT_BUILDER_EXPLORER : VIEWS.INTEGRATOR_EXPLORER;
 }

--- a/wi/wi-extension/src/stateMachine.ts
+++ b/wi/wi-extension/src/stateMachine.ts
@@ -30,7 +30,7 @@ import {
     ViewType
 } from '@wso2/wi-core';
 import { ext } from './extensionVariables';
-import { getProductMode, getProductName, isAgentBuilderMode } from './productMode';
+import { getExplorerViewId, getProductMode, getProductName, isAgentBuilderMode } from './productMode';
 import { fetchProjectInfo, fetchExtendedProjectInfo } from './bi/utils';
 import { activateProjectExplorer } from './bi/project-explorer/activate';
 import { ProjectExplorerEntryProvider } from './bi/project-explorer/project-explorer-provider';
@@ -299,7 +299,7 @@ const stateMachine = createMachine<MachineContext>({
             }
             vscode.commands.executeCommand('setContext', 'WI.projectType', 'none');
             void context.webviewManager.showWelcome().catch((error) => ext.logError("Failed to show welcome webview", error as Error));
-            context.currentView = ViewType.WELCOME;
+            context.currentView = isAgentBuilderMode() ? ViewType.AGENT_BUILDER_WELCOME : ViewType.WELCOME;
         },
         registerConfigChangeListener: (context) => {
             if (context.configChangeDisposable) {
@@ -388,7 +388,7 @@ async function activateExtensionsBasedOnProjectType(context: MachineContext): Pr
     await vscode.commands.executeCommand("setContext", CONTEXT_KEYS.MI_AVAILABLE, context.extensionAPIs.isMIAvailable());
 
     // focus avtivated extension view if a workspace is open
-    await vscode.commands.executeCommand('wso2-integrator.explorer.focus');
+    await vscode.commands.executeCommand(`${getExplorerViewId()}.focus`);
 
     ext.log('Extensions activated successfully');
 }

--- a/wi/wi-webviews/src/views/agentBuilderWelcome/index.tsx
+++ b/wi/wi-webviews/src/views/agentBuilderWelcome/index.tsx
@@ -25,11 +25,8 @@ import { UserAccountPopover } from "../UserAccountPopover";
 import { RemoteBIProjectForm } from "../creationView/federation/RemoteBIProjectForm";
 import { prefetchBiCreateFlow } from "../creationView/federation/biFormRemote";
 import { SamplesView } from "../samplesView";
-import { SettingsView } from "../settingsView";
 import {
 	ActionCard,
-	BALLERINA_MISSING_ACTION_TOOLTIP,
-	BALLERINA_MISSING_CONFIGURE_TOOLTIP,
 	ButtonContent,
 	Caption,
 	CardButtonRow,
@@ -40,7 +37,6 @@ import {
 	CardTitle,
 	CardsContainer,
 	CardsGrid,
-	ConfigureBtn,
 	GetStartedBadge,
 	Headline,
 	RecentProjectsPanel,
@@ -68,11 +64,15 @@ enum ViewState {
 	WELCOME = "welcome",
 	CREATE_PROJECT = "create_project",
 	SAMPLES = "samples",
-	SETTINGS = "settings",
 	OPEN_PROJECT = "open_project",
 }
 
 const DEFAULT_PRODUCT_NAME = "WSO2 Agent Builder";
+
+// The agent welcome has no Configure entry point yet, so the tooltip points at
+// the tree view's "Set Up Ballerina" flow instead of a Configure button.
+const BALLERINA_MISSING_TOOLTIP =
+	"Ballerina distribution is missing. Set it up to continue.";
 
 export const AgentBuilderWelcomeView: React.FC = () => {
 	const { wsClient, webviewContext } = useVisualizerContext();
@@ -120,7 +120,6 @@ export const AgentBuilderWelcomeView: React.FC = () => {
 
 	const goToCreate = () => setCurrentView(ViewState.CREATE_PROJECT);
 	const goToSamples = () => setCurrentView(ViewState.SAMPLES);
-	const goToSettings = () => setCurrentView(ViewState.SETTINGS);
 	const goToOpenProject = () => setCurrentView(ViewState.OPEN_PROJECT);
 	const goBackToWelcome = () => setCurrentView(ViewState.WELCOME);
 
@@ -188,27 +187,6 @@ export const AgentBuilderWelcomeView: React.FC = () => {
 									Sign In
 								</SigninBtn>
 							)}
-							<ConfigureBtn
-								type="button"
-								onClick={goToSettings}
-								title={
-									biUnavailable
-										? BALLERINA_MISSING_CONFIGURE_TOOLTIP
-										: undefined
-								}
-							>
-								<Codicon name="settings-gear" iconSx={{ fontSize: 16 }} />
-								<span>Configure</span>
-								{biUnavailable && (
-									<Codicon
-										name="warning"
-										iconSx={{
-											fontSize: 16,
-											color: "var(--vscode-editorWarning-foreground, #cca700)",
-										}}
-									/>
-								)}
-							</ConfigureBtn>
 						</TopBtnSection>
 					</TopControlsSection>
 					<GetStartedBadge>Get Started</GetStartedBadge>
@@ -224,9 +202,7 @@ export const AgentBuilderWelcomeView: React.FC = () => {
 					<CardsGrid>
 						<StaticActionCard
 							disabled={biUnavailable}
-							title={
-								biUnavailable ? BALLERINA_MISSING_ACTION_TOOLTIP : undefined
-							}
+							title={biUnavailable ? BALLERINA_MISSING_TOOLTIP : undefined}
 						>
 							<CardIconContainer>
 								<CardIcon bgColor="linear-gradient(135deg, var(--wso2-brand-primary-alt) 0%, var(--wso2-brand-primary-deep) 100%)">
@@ -264,9 +240,7 @@ export const AgentBuilderWelcomeView: React.FC = () => {
 						<ActionCard
 							disabled={biUnavailable}
 							onClick={biUnavailable ? undefined : goToSamples}
-							title={
-								biUnavailable ? BALLERINA_MISSING_ACTION_TOOLTIP : undefined
-							}
+							title={biUnavailable ? BALLERINA_MISSING_TOOLTIP : undefined}
 						>
 							<CardIconContainer>
 								<CardIcon bgColor="linear-gradient(135deg, var(--wso2-brand-accent) 0%, var(--wso2-brand-accent-alt) 100%)">
@@ -329,13 +303,6 @@ export const AgentBuilderWelcomeView: React.FC = () => {
 				);
 			case ViewState.SAMPLES:
 				return <SamplesView onBack={goBackToWelcome} runtime="WSO2: BI" />;
-			case ViewState.SETTINGS:
-				return (
-					<SettingsView
-						onBack={goBackToWelcome}
-						ballerinaUnavailable={biUnavailable}
-					/>
-				);
 			case ViewState.OPEN_PROJECT:
 				return <OpenProjectView onBack={goBackToWelcome} />;
 			case ViewState.WELCOME:

--- a/wi/wi-webviews/src/views/setup/CompactContent.tsx
+++ b/wi/wi-webviews/src/views/setup/CompactContent.tsx
@@ -17,6 +17,7 @@
  */
 
 import styled from "@emotion/styled";
+import { ProductMode } from "@wso2/wi-core";
 import { Button, Codicon } from "@wso2/ui-toolkit";
 import { useVisualizerContext } from "../../contexts";
 import {
@@ -111,8 +112,13 @@ const CompactErrorSection = styled.div`
 `;
 
 export function SetupContent() {
-    const { wsClient } = useVisualizerContext();
+    const { wsClient, webviewContext } = useVisualizerContext();
     const { progress, setProgress, isStarting, setIsStarting, isSetupRunning, handleRestart } = useSetupProgress();
+    // Agent Builder is BI-only, so there is no profile to switch to.
+    const isAgentBuilderMode = webviewContext?.productMode === ProductMode.AGENT_BUILDER;
+    const requiresBallerinaCaption = isAgentBuilderMode
+        ? `${webviewContext?.productName ?? "WSO2 Agent Builder"} requires the Ballerina distribution. You can set it up now.`
+        : "The WSO2 Integrator: Default Profile requires the Ballerina distribution. You can switch to a different profile above, or set it up now.";
 
     const handleSetup = async () => {
         setIsStarting(true);
@@ -136,8 +142,7 @@ export function SetupContent() {
                 <CompactHeaderText>
                     <CompactTitle>Ballerina Distribution Not Found</CompactTitle>
                     <CompactCaption>
-                        The WSO2 Integrator: Default Profile requires the Ballerina distribution.
-                        You can switch to a different profile above, or set it up now.
+                        {requiresBallerinaCaption}
                     </CompactCaption>
                 </CompactHeaderText>
             </CompactHeader>


### PR DESCRIPTION
## What this PR does

Follow-up fixes for the Agent Builder product flavor, found while testing the extension-host (F5) and full-product dev flows:

- **Welcome routing fix**: the `Open Welcome Page` command (`wso2.integrator.openWelcome`) was hardcoded to `ViewType.WELCOME`, so the Integrator welcome opened even in agent mode — this was the only welcome path in extension-host runs, masking the mode entirely. It now routes by product mode (same fix applied to the `showWelcomeScreen` state-machine action).
- **Activity bar / side panel branding**: contributes a second view container (`wso2-agent-builder`, titled "WSO2 Agent Builder") holding an "Agents" view, with `when` clauses on `WI.productMode` so only the active flavor's container appears (VS Code hides containers whose views are all hidden). The tree, progress indicator, and focus calls bind to the mode's view id via a new `getExplorerViewId()`; all tree menus accept either view id; flavor-specific viewsWelcome entries target their own container's view. Panel header in agent mode now reads "WSO2 Agent Builder: AGENTS".
- **Configure button hidden** on the agent welcome (no agent-mode configs yet); its settings sub-view was removed and the Ballerina-missing tooltip no longer references it.
- **Mode-aware Ballerina setup caption**: the setup panel said "The WSO2 Integrator: Default Profile requires the Ballerina distribution…"; in agent mode it now uses the product name and drops the profile-switching advice.
- **Dev workflow**: adds a "Run WI Extension (Agent Builder)" launch config. The default launch config, `.env.example`, `update-product.sh`, and CI inputs all stay `integrator` — agent-builder remains strictly opt-in.
- Logs the resolved product mode at activation for easier diagnosis.

## Testing

- `rush build --to wso2-integrator` green (wi-core, wi-webviews, wi-extension).
- F5 extension host in both flavors: Integrator default unchanged; Agent Builder shows the agent welcome, "WSO2 Agent Builder" activity icon + "AGENTS" panel, no Configure button.
- Verified the Integrator flavor renders identically to before (mode-gated container, menus accept both view ids).

🤖 Generated with [Claude Code](https://claude.com/claude-code)