### PR TITLE
Address review comments on the marketplace publish workflow

### DIFF
--- a/.github/workflows/reusable-publish-vsix.yml
+++ b/.github/workflows/reusable-publish-vsix.yml
@@ -11,16 +11,16 @@ on:
         description: 'Release tag to publish from, e.g. v5.1.0'
         required: true
         type: string
+      # No defaults: a workflow_call input that is `required` can never fall back to one, and
+      # both callers pass these explicitly.
       vscode:
         description: 'Publish to VS Code Marketplace'
         required: true
         type: boolean
-        default: true
       openVSX:
         description: 'Publish to Open VSX marketplace'
         required: true
         type: boolean
-        default: true
     secrets:
       VSCE_TOKEN:
         required: false
@@ -78,9 +78,11 @@ jobs:
         with:
           node-version: 20.x
 
+      # Pinned: these run with marketplace tokens, so the version that publishes should be the
+      # version that was reviewed, not whatever npm resolves that morning.
       - name: Install publishing CLIs
         run: |
-          npm install -g @vscode/vsce ovsx
+          npm install -g @vscode/vsce@3.9.2 ovsx@1.1.1
 
       - name: Publish to VS Code Marketplace
         if: ${{ inputs.vscode }}


### PR DESCRIPTION
## Purpose
Addresses two review findings raised on #2168 (`staging/5.1.0` → `main`) so the same fixes also land directly on `staging/5.1.0`.

## Approach
`.github/workflows/reusable-publish-vsix.yml`:

- **Dropped `default: true` from the required `vscode` / `openVSX` `workflow_call` inputs.** A `required: true` `workflow_call` input can never fall back to a default, and actionlint flags the combination as an error. Both callers — `release.yml` (`publish-marketplace`) and `publish-vsix.yml` — already pass both values explicitly. The identical-looking defaults on `publish-vsix.yml`'s `workflow_dispatch` inputs are left as-is: dispatch defaults *are* used, and they pre-fill the manual run form.
- **Pinned the publishing CLIs** to `@vscode/vsce@3.9.2` and `ovsx@1.1.1`. These run with marketplace tokens, so the version that publishes should be the version that was reviewed rather than whatever npm resolves that morning. Both declare `engines.node >= 20`, matching the workflow's Node 20.x.

Not changed: the third review comment asked for `--paginate --slurp` in `ci/build/resolve-nightly-versions.sh`. The mechanics of that suggestion are right, but the premise does not hold for our upstreams — `wso2/ballerina-vscode`'s rolling `nightly` release is recreated each night so it always sits at the top of page 1, and page 1 of that repo currently reaches back ~16 months, so the newest-by-asset-timestamp fallback is never on page 2. Full pagination would cost 6–7 extra API calls per component per nightly run, which works against the rate-limit budgeting the script already does.

## Release note
N/A — CI-only change.

## Documentation
N/A — no user-facing or documented behaviour changes.

## Automation tests
N/A. Workflow YAML parses; the pinned CLI versions are the current latest and are Node 20 compatible.

## Security checks
- Followed secure coding standards: yes
- Ran FindSecurityBugs plugin and verified report? N/A — no Java changes
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
- #2168
