### PR TITLE
Make installers and smoke tests product-flavor aware

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -244,6 +244,7 @@ jobs:
       # must read that script from the commit under test, not from the caller's triggering ref.
       ref: ${{ inputs.ref }}
       allow_failure: ${{ inputs.smoke_tests_required == false }}
+      product_name: ${{ inputs.product_flavor == 'agent-builder' && 'WSO2 Agent Builder' || 'WSO2 Integrator' }}
 
   smoke-test-windows:
     if: ${{ inputs.build_windows == true && inputs.build_packed_installers == true && inputs.run_smoke_tests == true }}
@@ -253,6 +254,7 @@ jobs:
       windows_artifact_name: Product-Integrator-Windows
       ref: ${{ inputs.ref }}
       allow_failure: ${{ inputs.smoke_tests_required == false }}
+      product_name: ${{ inputs.product_flavor == 'agent-builder' && 'WSO2 Agent Builder' || 'WSO2 Integrator' }}
 
   build-macos:
     if: ${{ inputs.build_macos == true }}
@@ -1200,11 +1202,12 @@ jobs:
         env:
           PUBLISH_TAG: ${{ inputs.publish_tag }}
           INTEGRATOR_VERSION: ${{ needs.resolve-versions.outputs.integrator_version }}
+          PRODUCT_NAME: ${{ inputs.product_flavor == 'agent-builder' && 'WSO2 Agent Builder' || 'WSO2 Integrator' }}
         run: |
           if [ "${PUBLISH_TAG}" = "nightly" ]; then
-            echo "name=WSO2 Integrator Nightly (${INTEGRATOR_VERSION})" >> "$GITHUB_OUTPUT"
+            echo "name=${PRODUCT_NAME} Nightly (${INTEGRATOR_VERSION})" >> "$GITHUB_OUTPUT"
           else
-            echo "name=WSO2 Integrator ${PUBLISH_TAG}" >> "$GITHUB_OUTPUT"
+            echo "name=${PRODUCT_NAME} ${PUBLISH_TAG}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: List release files

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -26,6 +26,11 @@ on:
         required: false
         type: boolean
         default: false
+      product_name:
+        description: "Product display name (product.json nameShort/nameLong) — names the Windows exe and the user-data directory. 'WSO2 Integrator' or 'WSO2 Agent Builder'."
+        required: false
+        type: string
+        default: 'WSO2 Integrator'
   workflow_dispatch:
     inputs:
       integrator_version:
@@ -200,7 +205,7 @@ jobs:
           # product.nameShort to getUserDataPath(), and getDefaultUserDataPath() joins it onto
           # $XDG_CONFIG_HOME (or ~/.config) on Linux. nameShort is set in ci/build/update-product.sh.
           # Copying only that tree keeps unrelated logs out of the artifact.
-          USER_DATA="${XDG_CONFIG_HOME:-$HOME/.config}/WSO2 Integrator"
+          USER_DATA="${XDG_CONFIG_HOME:-$HOME/.config}/${{ inputs.product_name || 'WSO2 Integrator' }}"
           if [ -d "${USER_DATA}/logs" ]; then
             cp -R "${USER_DATA}/logs" editor-logs/
           else
@@ -279,9 +284,10 @@ jobs:
           $proc = Start-Process msiexec.exe -ArgumentList "/i `"$($msi.FullName)`" /qn /norestart INTEGRATORFOLDER=`"$installDir`"" -Wait -PassThru
           Write-Host "msiexec exit code: $($proc.ExitCode)"
           if ($proc.ExitCode -ne 0) { throw "msiexec failed with exit code $($proc.ExitCode)" }
-          $binary = Get-ChildItem $installDir -Recurse -Filter 'WSO2 Integrator.exe' -Depth 2 |
+          $exeName = '${{ inputs.product_name || 'WSO2 Integrator' }}.exe'
+          $binary = Get-ChildItem $installDir -Recurse -Filter $exeName -Depth 2 |
             Select-Object -First 1
-          if (-not $binary) { throw 'WSO2 Integrator.exe not found' }
+          if (-not $binary) { throw "$exeName not found" }
           "WSO2_INTEGRATOR_PATH=$($binary.FullName)" | Out-File -Append $env:GITHUB_ENV
           # Exclude from Defender to avoid I/O throttling
           Add-MpPreference -ExclusionPath $installDir

--- a/installers/mac/Distribution.xml
+++ b/installers/mac/Distribution.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <installer-gui-script minSpecVersion="1">
-    <title>WSO2 Integrator</title>
+    <title>__PRODUCT_NAME__</title>
     <organization>com.wso2.integrator</organization>
     <domains enable_localSystem="true" enable_currentUserOnly="false" enable_currentUserHome="false" />
     <options customize="never" require-scripts="false" rootVolumeOnly="true" />
@@ -13,7 +13,7 @@
         function checkSystem() {
             if(!(system.compareVersions(system.version.ProductVersion, '10.13.0') >= 0)){
                 my.result.title = 'Unable to install';
-                my.result.message = 'WSO2 Integrator requires Mac OS X 10.13 or later.';
+                my.result.message = '__PRODUCT_NAME__ requires Mac OS X 10.13 or later.';
                 my.result.type = 'Fatal';
                 return false;
             }
@@ -30,5 +30,5 @@
     <choice id="com.wso2.integrator" visible="false">
         <pkg-ref id="com.wso2.integrator" />
     </choice>
-    <pkg-ref id="com.wso2.integrator" version="__VERSION__" onConclusion="none" auth="none">WSO2 Integrator.pkg</pkg-ref>
+    <pkg-ref id="com.wso2.integrator" version="__VERSION__" onConclusion="none" auth="none">__PRODUCT_NAME__.pkg</pkg-ref>
 </installer-gui-script>

--- a/installers/mac/build.sh
+++ b/installers/mac/build.sh
@@ -50,8 +50,20 @@ WSO2_UNZIPPED_FOLDER=$(unzip -Z1 "$WSO2_ZIP" | head -1 | cut -d/ -f1)
 WSO2_UNZIPPED_PATH="$EXTRACTION_TARGET/$WSO2_UNZIPPED_FOLDER"
 mv "$WSO2_UNZIPPED_PATH"/* "$WSO2_TARGET"
 rm -rf "$WSO2_UNZIPPED_PATH"
-chmod +x "$WSO2_TARGET/WSO2 Integrator.app/Contents/MacOS"/* 2>/dev/null || true
-xattr -cr "$WSO2_TARGET/WSO2 Integrator.app"
+
+# The .app bundle is named after product.json nameLong, which depends on the
+# product flavor ("WSO2 Integrator" / "WSO2 Agent Builder"), so detect it from
+# the payload instead of hardcoding it.
+APP_BUNDLE=$(cd "$WSO2_TARGET" && ls -d *.app 2>/dev/null | head -1)
+if [ -z "$APP_BUNDLE" ]; then
+    print_error "No .app bundle found in $WSO2_TARGET"
+    exit 1
+fi
+APP_NAME="${APP_BUNDLE%.app}"
+print_info "Detected app bundle: $APP_BUNDLE"
+
+chmod +x "$WSO2_TARGET/$APP_BUNDLE/Contents/MacOS"/* 2>/dev/null || true
+xattr -cr "$WSO2_TARGET/$APP_BUNDLE"
 
 rm -rf "$EXTRACTION_TARGET/__MACOSX"
 
@@ -66,7 +78,7 @@ if [ "$ARCH" = "x64" ]; then
 else
     CHOREO_ARCH="$ARCH"
 fi
-CHOREO_CLI_DIR="$WSO2_TARGET/WSO2 Integrator.app/Contents/Resources/app/extensions/wso2.wso2-integrator/resources/choreo-cli"
+CHOREO_CLI_DIR="$WSO2_TARGET/$APP_BUNDLE/Contents/Resources/app/extensions/wso2.wso2-integrator/resources/choreo-cli"
 if [ -d "$CHOREO_CLI_DIR" ]; then
     print_info "Pruning choreo-cli binaries to darwin/$CHOREO_ARCH only"
     for VERSION_DIR in "$CHOREO_CLI_DIR"/*/; do
@@ -88,7 +100,7 @@ fi
 
 # Extract Ballerina zip
 print_info "Extracting Ballerina to package resources"
-COMPONENTS_DIR="$WORK_DIR/payload/Applications/WSO2 Integrator.app/Contents/components"
+COMPONENTS_DIR="$WORK_DIR/payload/Applications/$APP_BUNDLE/Contents/components"
 BALLERINA_TARGET="$COMPONENTS_DIR/ballerina"
 rm -rf "$BALLERINA_TARGET"
 mkdir -p "$BALLERINA_TARGET"
@@ -160,7 +172,14 @@ if [ -f "$ICP_SCRIPT" ]; then
 fi
 
 # Fix ZIP epoch timestamps — unzip preserves 1980-01-01 dates from ZIP archives
-find "$WSO2_TARGET/WSO2 Integrator.app" -exec touch {} +
+find "$WSO2_TARGET/$APP_BUNDLE" -exec touch {} +
+
+# Resolve the product-name placeholder in packaging metadata (same in-place
+# substitute/restore pattern as __VERSION__ in Distribution.xml).
+sed -i '' "s/__PRODUCT_NAME__/$APP_NAME/g" "$WORK_DIR/component.plist"
+sed -i '' "s/__PRODUCT_NAME__/$APP_NAME/g" "$WORK_DIR/Distribution.xml"
+sed -i '' "s/__PRODUCT_NAME__/$APP_NAME/g" "$WORK_DIR/welcome.html"
+sed -i '' "s/__PRODUCT_NAME__/$APP_NAME/g" "$WORK_DIR/conclusion.html"
 
 # Build the component package
 pkgbuild --root "$EXTRACTION_TARGET" \
@@ -169,7 +188,7 @@ pkgbuild --root "$EXTRACTION_TARGET" \
          --install-location "/" \
          --ownership preserve \
          --component-plist "$WORK_DIR/component.plist" \
-         "$WORK_DIR/WSO2 Integrator.pkg"
+         "$WORK_DIR/$APP_NAME.pkg"
 
 sed -i '' "s/version=\"__VERSION__\"/version=\"$VERSION\"/g" "$WORK_DIR/Distribution.xml"
 
@@ -181,6 +200,12 @@ productbuild --distribution "$WORK_DIR/Distribution.xml" \
              "wso2-integrator-$VERSION-$ARCH.pkg"
 
 sed -i '' "s/version=\"$VERSION\"/version=\"__VERSION__\"/g" "$WORK_DIR/Distribution.xml"
+
+# Restore the product-name placeholders
+sed -i '' "s/$APP_NAME/__PRODUCT_NAME__/g" "$WORK_DIR/component.plist"
+sed -i '' "s/$APP_NAME/__PRODUCT_NAME__/g" "$WORK_DIR/Distribution.xml"
+sed -i '' "s/$APP_NAME/__PRODUCT_NAME__/g" "$WORK_DIR/welcome.html"
+sed -i '' "s/$APP_NAME/__PRODUCT_NAME__/g" "$WORK_DIR/conclusion.html"
 
 
 # Check if the build was successful
@@ -196,7 +221,7 @@ fi
 # Build the DMG
 # -------------------------------------------------------------------
 
-APP_NAME="WSO2 Integrator"
+# APP_NAME was detected from the payload above (flavor-dependent).
 DMG_NAME="wso2-integrator-$VERSION-$ARCH.dmg"
 DMG_STAGING="$WORK_DIR/dmg_staging"
 
@@ -322,6 +347,6 @@ rm -rf "${ICP_TARGET:?}"/*
 rm -rf "${BALLERINA_TARGET:?}"/*
 rm -rf "$EXTRACTION_TARGET/Library"
 rm -rf "$EXTRACTION_TARGET/Applications"
-rm -rf "$WORK_DIR/WSO2 Integrator.pkg"
+rm -rf "$WORK_DIR/$APP_NAME.pkg"
 
 print_info "Done!"

--- a/installers/mac/component.plist
+++ b/installers/mac/component.plist
@@ -12,7 +12,7 @@
         <key>BundleOverwriteAction</key>
         <string>upgrade</string>
         <key>RootRelativeBundlePath</key>
-        <string>Applications/WSO2 Integrator.app</string>
+        <string>Applications/__PRODUCT_NAME__.app</string>
     </dict>
 </array>
 </plist>

--- a/installers/mac/conclusion.html
+++ b/installers/mac/conclusion.html
@@ -49,9 +49,9 @@
 	<div class="container">
 		<div class="success-icon">&#10004;</div>
 		<h1>Installation Complete!</h1>
-		<p><b>WSO2 Integrator</b> has been successfully installed to your <b>Applications</b> folder.</p>
-		<p>You can find it at:<br><b>/Applications/WSO2 Integrator.app</b></p>
-		<p>Thank you for choosing WSO2 Integrator.<br>We hope you enjoy your experience!</p>
+		<p><b>__PRODUCT_NAME__</b> has been successfully installed to your <b>Applications</b> folder.</p>
+		<p>You can find it at:<br><b>/Applications/__PRODUCT_NAME__.app</b></p>
+		<p>Thank you for choosing __PRODUCT_NAME__.<br>We hope you enjoy your experience!</p>
 	</div>
 </body>
 </html>

--- a/installers/mac/welcome.html
+++ b/installers/mac/welcome.html
@@ -43,9 +43,9 @@
 	<div class="container">
 		<!-- Optional: Add a logo image here -->
 		<!-- <img src="logo.png" alt="WSO2 Logo" class="logo"> -->
-		<h1>Welcome to WSO2 Integrator</h1>
-		<p>Thank you for choosing WSO2 Integrator.<br>
-		This installer will guide you through the installation process and set up WSO2 Integrator in your <b>Applications</b> folder.<br><br>
+		<h1>Welcome to __PRODUCT_NAME__</h1>
+		<p>Thank you for choosing __PRODUCT_NAME__.<br>
+		This installer will guide you through the installation process and set up __PRODUCT_NAME__ in your <b>Applications</b> folder.<br><br>
 		Click <b>Continue</b> to proceed.</p>
 	</div>
 </body>

--- a/installers/windows/CustomAction1/CustomAction.cs
+++ b/installers/windows/CustomAction1/CustomAction.cs
@@ -254,7 +254,10 @@ namespace CustomAction1
                         if (System.IO.Directory.Exists(appDataRoaming))
                         {
                             session.Log($"AppData\\Roaming directory found: {appDataRoaming}");
-                            string targetDir = System.IO.Path.Combine(appDataRoaming, "WSO2 Integrator", "User");
+                            // The app's user-data dir is named after product.json nameShort,
+                            // which depends on the product flavor. build.bat resolves the
+                            // placeholder from the payload's exe name before compiling.
+                            string targetDir = System.IO.Path.Combine(appDataRoaming, "@PRODUCT_NAME@", "User");
                             if (!System.IO.Directory.Exists(targetDir))
                             {
                                 System.IO.Directory.CreateDirectory(targetDir);

--- a/installers/windows/WixPackage/IntegratorComponents.wxs
+++ b/installers/windows/WixPackage/IntegratorComponents.wxs
@@ -3,7 +3,7 @@
   <Fragment>
     <ComponentGroup Id="IntegratorComponents" Directory="INTEGRATORFOLDER">
       <Files Include=".\payload\Integrator\**">
-        <Exclude Files=".\payload\Integrator\WSO2 Integrator.exe" />
+        <Exclude Files=".\payload\Integrator\@PRODUCT_NAME@.exe" />
       </Files>
     </ComponentGroup>
 
@@ -13,14 +13,14 @@
         Type="integer" Value="1" KeyPath="yes" />
 
       <File Id="IntegratorExe"
-        Source=".\payload\Integrator\WSO2 Integrator.exe" />
+        Source=".\payload\Integrator\@PRODUCT_NAME@.exe" />
 
       <!-- Desktop Shortcut -->
       <Shortcut Id="DesktopShortcut"
         Directory="DesktopFolder"
-        Name="WSO2 Integrator"
-        Description="Launch WSO2 Integrator"
-        Target="[INTEGRATORFOLDER]WSO2 Integrator.exe"
+        Name="@PRODUCT_NAME@"
+        Description="Launch @PRODUCT_NAME@"
+        Target="[INTEGRATORFOLDER]@PRODUCT_NAME@.exe"
         WorkingDirectory="INTEGRATORFOLDER"
         Icon="Integrator.exe"
         IconIndex="0" />
@@ -28,9 +28,9 @@
       <!-- Start Menu Shortcut -->
       <Shortcut Id="StartMenuShortcut"
         Directory="ProgramMenuFolder"
-        Name="WSO2 Integrator"
-        Description="Launch WSO2 Integrator"
-        Target="[INTEGRATORFOLDER]WSO2 Integrator.exe"
+        Name="@PRODUCT_NAME@"
+        Description="Launch @PRODUCT_NAME@"
+        Target="[INTEGRATORFOLDER]@PRODUCT_NAME@.exe"
         WorkingDirectory="INTEGRATORFOLDER"
         Icon="Integrator.exe"
         IconIndex="0" />

--- a/installers/windows/WixPackage/Package.wxs
+++ b/installers/windows/WixPackage/Package.wxs
@@ -1,7 +1,7 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs"
   xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util"
   xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
-  <Package Name="WSO2 Integrator"
+  <Package Name="@PRODUCT_NAME@"
     Version="@VERSION@"
     Manufacturer="WSO2"
     UpgradeCode="344b046a-fa6a-4452-be40-2794f59fe7b0"

--- a/installers/windows/build.bat
+++ b/installers/windows/build.bat
@@ -101,6 +101,18 @@ for /f "delims=" %%v in ('powershell -nologo -noprofile -command "('%~6' -split 
 REM Update version in Package.wxs
 powershell -Command "(Get-Content '.\WixPackage\Package.wxs') -replace '@VERSION@', '%WIX_VERSION%' | Set-Content '.\WixPackage\Package.wxs'"
 
+REM The main executable is named after product.json nameShort, which depends on
+REM the product flavor ("WSO2 Integrator" / "WSO2 Agent Builder"). Detect it
+REM from the payload and resolve the @PRODUCT_NAME@ placeholders. Placeholder
+REM sources are backed up and restored via :restore_name on every exit path.
+for /f "delims=" %%p in ('powershell -nologo -noprofile -command "(Get-ChildItem '.\WixPackage\payload\Integrator' -Filter *.exe -File | Select-Object -First 1).BaseName"') do set "PRODUCT_NAME=%%p"
+if not defined PRODUCT_NAME set "PRODUCT_NAME=WSO2 Integrator"
+echo Product name: %PRODUCT_NAME%
+copy /y ".\WixPackage\Package.wxs" ".\WixPackage\Package.wxs.bak" >nul
+copy /y ".\WixPackage\IntegratorComponents.wxs" ".\WixPackage\IntegratorComponents.wxs.bak" >nul
+copy /y ".\CustomAction1\CustomAction.cs" ".\CustomAction1\CustomAction.cs.bak" >nul
+powershell -Command "foreach ($f in '.\WixPackage\Package.wxs','.\WixPackage\IntegratorComponents.wxs','.\CustomAction1\CustomAction.cs') { (Get-Content -Raw $f).Replace('@PRODUCT_NAME@', '%PRODUCT_NAME%') | Set-Content $f }"
+
 REM Map build directory to a short drive letter to keep file paths under 260 chars.
 REM wixnative.exe lacks a longPathAware manifest, so it crashes on paths > 260 chars.
 set "SCRIPT_DIR=%~dp0"
@@ -116,6 +128,7 @@ for %%L in (W X Y Z) do (
 )
 if not defined BUILD_DRIVE (
     echo ERROR: No available drive letter found ^(W-Z all in use or subst failed^)
+    call :restore_name
     powershell -Command "(Get-Content -Raw '.\WixPackage\Package.wxs').Replace('%WIX_VERSION%', '@VERSION@') | Set-Content '.\WixPackage\Package.wxs'"
     if exist ".\WixPackage\payload" rmdir /s /q ".\WixPackage\payload"
     exit /b 1
@@ -124,6 +137,7 @@ pushd %BUILD_DRIVE%:\
 if errorlevel 1 (
     echo ERROR: pushd into %BUILD_DRIVE%:\ failed
     subst %BUILD_DRIVE%: /D >nul 2>&1
+    call :restore_name
     powershell -Command "(Get-Content -Raw '.\WixPackage\Package.wxs').Replace('%WIX_VERSION%', '@VERSION@') | Set-Content '.\WixPackage\Package.wxs'"
     if exist ".\WixPackage\payload" rmdir /s /q ".\WixPackage\payload"
     exit /b 1
@@ -134,6 +148,7 @@ if errorlevel 1 (
     echo CustomAction1 build failed
     popd
     subst %BUILD_DRIVE%: /D
+    call :restore_name
     powershell -Command "(Get-Content -Raw '.\WixPackage\Package.wxs').Replace('%WIX_VERSION%', '@VERSION@') | Set-Content '.\WixPackage\Package.wxs'"
     exit /b 1
 )
@@ -142,6 +157,7 @@ if errorlevel 1 (
     echo WixPackage build failed
     popd
     subst %BUILD_DRIVE%: /D
+    call :restore_name
     powershell -Command "(Get-Content -Raw '.\WixPackage\Package.wxs').Replace('%WIX_VERSION%', '@VERSION@') | Set-Content '.\WixPackage\Package.wxs'"
     exit /b 1
 )
@@ -159,8 +175,19 @@ if exist "%MSI_ORIG%" (
     echo MSI file not found: %MSI_ORIG%
 )
 
-REM Revert version placeholder in Package.wxs
+REM Revert product-name and version placeholders
+call :restore_name
 powershell -Command "(Get-Content -Raw '.\WixPackage\Package.wxs').Replace('%WIX_VERSION%', '@VERSION@') | Set-Content '.\WixPackage\Package.wxs'"
 REM Remove payload and resources directories after build
 if exist ".\WixPackage\payload" rmdir /s /q ".\WixPackage\payload"
 endlocal
+exit /b 0
+
+REM Restores the @PRODUCT_NAME@ placeholder sources backed up before substitution.
+REM The backups were taken after the @VERSION@ substitution, so the caller's
+REM version-restore step still applies afterwards.
+:restore_name
+if exist ".\WixPackage\Package.wxs.bak" move /y ".\WixPackage\Package.wxs.bak" ".\WixPackage\Package.wxs" >nul
+if exist ".\WixPackage\IntegratorComponents.wxs.bak" move /y ".\WixPackage\IntegratorComponents.wxs.bak" ".\WixPackage\IntegratorComponents.wxs" >nul
+if exist ".\CustomAction1\CustomAction.cs.bak" move /y ".\CustomAction1\CustomAction.cs.bak" ".\CustomAction1\CustomAction.cs" >nul
+exit /b 0


### PR DESCRIPTION
## Problem

Dispatching a dev build with `product_flavor: agent-builder` fails in every installer packaging job (e.g. [run 32338291432](https://github.com/wso2/product-integrator/actions/runs/32338291432)):

- **macOS**: `xattr: No such file: …/payload/Applications/WSO2 Integrator.app`
- **Windows**: `WIX0103: Cannot find the File file '.\payload\Integrator\WSO2 Integrator.exe'`

Root cause: gulp names the platform binaries after product.json `nameShort`/`nameLong` — the agent-builder flavor produces `WSO2 Agent Builder.app` / `WSO2 Agent Builder.exe` — while the installer scripts hardcode the "WSO2 Integrator" paths. (Linux passes because its binary is named from `applicationName`, which the flavor doesn't change.)

## Fix

Both installers now **detect the app name from their own payload** (so they always match whatever gulp produced) and resolve name placeholders using the same substitute/restore pattern already used for versions:

- **`installers/mac/build.sh`**: detects the `.app` bundle after extraction; `Distribution.xml`, `component.plist`, `welcome.html`, `conclusion.html` carry a `__PRODUCT_NAME__` placeholder, substituted before `pkgbuild`/`productbuild` and restored after (mirroring the existing `__VERSION__` sed).
- **`installers/windows/build.bat`**: detects the exe basename from the payload; `Package.wxs`, `IntegratorComponents.wxs`, and `CustomAction.cs` carry `@PRODUCT_NAME@` placeholders, backed up before substitution and restored on every exit path via a `:restore_name` subroutine. The CustomAction's `CommonAppData\WSO2 Integrator` *source* path is intentionally left hardcoded (it is seeded outside this repo — flagging as an open question); only the per-user `%APPDATA%\<name>\User` *target* follows the flavor, since that is where the flavored app reads its settings.
- **Smoke tests**: `smoke-test.yml` gains a `product_name` input used for the Windows exe discovery and the Linux user-data log directory; `build.yml` derives it from `product_flavor` and also uses it for the GitHub release title.

## Not changed

- Artifact filenames stay `wso2-integrator-*` (`.pkg`/`.dmg`/`.msi`) in both flavors, so downstream signing/upload steps are unaffected.
- Integrator-flavor builds resolve every placeholder to exactly the previous strings — byte-identical behavior.

## Testing

- `bash -n` on the mac script; workflow YAML lints clean; placeholder round-trip verified by inspection against the failing run's payload paths.
- The Windows batch flow needs a CI run to verify end-to-end — recommend re-dispatching a dev build with `product_flavor: agent-builder` after merge, plus one default-flavor build as regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)