### PR TITLE
Fully separate Agent Builder and Integrator app data and identity

### DIFF
--- a/ci/build/update-product.sh
+++ b/ci/build/update-product.sh
@@ -18,13 +18,30 @@ read_version() {
 # Accept integrator version as first arg (optional), otherwise read from source-of-truth file.
 VERSION=${1:-"$(read_version "integrator.version")"}
 
-# Product flavor decides the app-shell display name only; all identity fields
-# (applicationName, data folders, bundle ids, urlProtocol, ...) stay
-# wso2-integrator so both flavors share extension/URI/session contracts.
+# Product flavor decides the display name and the OS-level identity so the two
+# apps keep ALL data separate and install/run side by side:
+#  - DATA_FOLDER: user-installed extensions + CLI data (a shared folder lets an
+#    Integrator-installed WI extension shadow the Agent Builder built-in)
+#  - BUNDLE_ID: macOS Launch Services / Keychain / pkg receipts
+#  - APP_SLUG: Windows mutex (side-by-side run), AppUserModelId (taskbar), and
+#    the URL protocol (sign-in callbacks must reopen the SAME app; the
+#    extension builds callbacks from vscode.env.uriScheme, so this is safe)
+# applicationName and the extension/command ids stay wso2-integrator: one VSIX
+# serves both flavors.
 PRODUCT_FLAVOR=${PRODUCT_FLAVOR:-integrator}
 case "${PRODUCT_FLAVOR}" in
-  integrator)    PRODUCT_NAME="WSO2 Integrator" ;;
-  agent-builder) PRODUCT_NAME="WSO2 Agent Builder" ;;
+  integrator)
+    PRODUCT_NAME="WSO2 Integrator"
+    DATA_FOLDER=".wso2-integrator"
+    APP_SLUG="wso2-integrator"
+    BUNDLE_ID="com.wso2.integrator"
+    ;;
+  agent-builder)
+    PRODUCT_NAME="WSO2 Agent Builder"
+    DATA_FOLDER=".wso2-agent-builder"
+    APP_SLUG="wso2-agent-builder"
+    BUNDLE_ID="com.wso2.agentbuilder"
+    ;;
   *) echo "Error: unknown PRODUCT_FLAVOR '${PRODUCT_FLAVOR}' (expected 'integrator' or 'agent-builder')" >&2; exit 1 ;;
 esac
 BALLERINA_VSIX_PATH=${BALLERINA_VSIX_PATH:-""}
@@ -79,10 +96,10 @@ cat > lib/vscode/product.json <<EOF
     "nameShort": "${PRODUCT_NAME}",
     "nameLong": "${PRODUCT_NAME}",
     "applicationName": "wso2-integrator",
-    "dataFolderName": ".wso2-integrator",
-    "sharedDataFolderName": ".wso2-integrator-shared",
+    "dataFolderName": "${DATA_FOLDER}",
+    "sharedDataFolderName": "${DATA_FOLDER}-shared",
     "builtInExtensionsEnabledWithAutoUpdates": [],
-    "win32MutexName": "wso2-integrator",
+    "win32MutexName": "${APP_SLUG}",
     "licenseName": "MIT",
     "licenseUrl": "https://wso2.com/licenses/",
     "serverLicenseUrl": "https://wso2.com/licenses/",
@@ -90,15 +107,15 @@ cat > lib/vscode/product.json <<EOF
     "serverLicense": [],
     "serverLicensePrompt": "",
     "serverApplicationName": "wso2-integrator",
-    "serverDataFolderName": ".wso2-integrator",
+    "serverDataFolderName": "${DATA_FOLDER}",
     "tunnelApplicationName": "wso2-integrator-tunnel",
-    "win32DirName": "wso2-integrator",
-    "win32NameVersion": "wso2-integrator",
-    "win32AppUserModelId": "wso2.wso2-integrator",
+    "win32DirName": "${APP_SLUG}",
+    "win32NameVersion": "${APP_SLUG}",
+    "win32AppUserModelId": "wso2.${APP_SLUG}",
     "win32ShellNameShort": "w&so2-integrator",
-    "darwinBundleIdentifier": "com.wso2.integrator",
-    "linuxIconName": "com.wso2.integrator",
-    "urlProtocol": "wso2-integrator",
+    "darwinBundleIdentifier": "${BUNDLE_ID}",
+    "linuxIconName": "${BUNDLE_ID}",
+    "urlProtocol": "${APP_SLUG}",
     "licenseFileName": "LICENSE.txt",
     "reportIssueUrl": "https://github.com/wso2/product-integrator/issues",
     "documentationUrl": "https://wso2.com/integration-platform/docs/",

--- a/installers/mac/Distribution.xml
+++ b/installers/mac/Distribution.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <installer-gui-script minSpecVersion="1">
     <title>__PRODUCT_NAME__</title>
-    <organization>com.wso2.integrator</organization>
+    <organization>__BUNDLE_ID__</organization>
     <domains enable_localSystem="true" enable_currentUserOnly="false" enable_currentUserHome="false" />
     <options customize="never" require-scripts="false" rootVolumeOnly="true" />
     <welcome file="welcome.html" />
@@ -23,12 +23,12 @@
     </script>
     <choices-outline>
         <line choice="default">
-            <line choice="com.wso2.integrator" />
+            <line choice="__BUNDLE_ID__" />
         </line>
     </choices-outline>
     <choice id="default" />
-    <choice id="com.wso2.integrator" visible="false">
-        <pkg-ref id="com.wso2.integrator" />
+    <choice id="__BUNDLE_ID__" visible="false">
+        <pkg-ref id="__BUNDLE_ID__" />
     </choice>
-    <pkg-ref id="com.wso2.integrator" version="__VERSION__" onConclusion="none" auth="none">__PRODUCT_NAME__.pkg</pkg-ref>
+    <pkg-ref id="__BUNDLE_ID__" version="__VERSION__" onConclusion="none" auth="none">__PRODUCT_NAME__.pkg</pkg-ref>
 </installer-gui-script>

--- a/installers/mac/build.sh
+++ b/installers/mac/build.sh
@@ -38,7 +38,6 @@ VERSION="$6"
 ARCH="$7"
 
 OUTPUT_PKG="WSO2_Integrator.pkg"
-BUNDLE_IDENTIFIER="com.wso2.integrator"
 EXTRACTION_TARGET="$WORK_DIR/payload"
 
 # Extract wso2 zip
@@ -61,6 +60,14 @@ if [ -z "$APP_BUNDLE" ]; then
 fi
 APP_NAME="${APP_BUNDLE%.app}"
 print_info "Detected app bundle: $APP_BUNDLE"
+
+# The pkg identifier must match the app's darwinBundleIdentifier so each
+# flavor keeps its own installer receipts (side-by-side installs).
+case "$APP_NAME" in
+    "WSO2 Agent Builder") BUNDLE_IDENTIFIER="com.wso2.agentbuilder" ;;
+    *)                    BUNDLE_IDENTIFIER="com.wso2.integrator" ;;
+esac
+print_info "Package identifier: $BUNDLE_IDENTIFIER"
 
 chmod +x "$WSO2_TARGET/$APP_BUNDLE/Contents/MacOS"/* 2>/dev/null || true
 xattr -cr "$WSO2_TARGET/$APP_BUNDLE"
@@ -178,6 +185,7 @@ find "$WSO2_TARGET/$APP_BUNDLE" -exec touch {} +
 # substitute/restore pattern as __VERSION__ in Distribution.xml).
 sed -i '' "s/__PRODUCT_NAME__/$APP_NAME/g" "$WORK_DIR/component.plist"
 sed -i '' "s/__PRODUCT_NAME__/$APP_NAME/g" "$WORK_DIR/Distribution.xml"
+sed -i '' "s/__BUNDLE_ID__/$BUNDLE_IDENTIFIER/g" "$WORK_DIR/Distribution.xml"
 sed -i '' "s/__PRODUCT_NAME__/$APP_NAME/g" "$WORK_DIR/welcome.html"
 sed -i '' "s/__PRODUCT_NAME__/$APP_NAME/g" "$WORK_DIR/conclusion.html"
 
@@ -201,8 +209,9 @@ productbuild --distribution "$WORK_DIR/Distribution.xml" \
 
 sed -i '' "s/version=\"$VERSION\"/version=\"__VERSION__\"/g" "$WORK_DIR/Distribution.xml"
 
-# Restore the product-name placeholders
+# Restore the product-name and bundle-id placeholders
 sed -i '' "s/$APP_NAME/__PRODUCT_NAME__/g" "$WORK_DIR/component.plist"
+sed -i '' "s/$BUNDLE_IDENTIFIER/__BUNDLE_ID__/g" "$WORK_DIR/Distribution.xml"
 sed -i '' "s/$APP_NAME/__PRODUCT_NAME__/g" "$WORK_DIR/Distribution.xml"
 sed -i '' "s/$APP_NAME/__PRODUCT_NAME__/g" "$WORK_DIR/welcome.html"
 sed -i '' "s/$APP_NAME/__PRODUCT_NAME__/g" "$WORK_DIR/conclusion.html"

--- a/installers/windows/WixPackage/Folders.wxs
+++ b/installers/windows/WixPackage/Folders.wxs
@@ -3,7 +3,7 @@
 		<StandardDirectory Id="LocalAppDataFolder">
 			<Directory Id="LocalProgramsDir" Name="Programs">
 				<Directory Id="INSTALLFOLDER" Name="WSO2">
-					<Directory Id="INTEGRATORFOLDER" Name="Integrator" />
+					<Directory Id="INTEGRATORFOLDER" Name="@PRODUCT_DIR@" />
 				</Directory>
 			</Directory>
 		</StandardDirectory>

--- a/installers/windows/WixPackage/Package.wxs
+++ b/installers/windows/WixPackage/Package.wxs
@@ -4,7 +4,7 @@
   <Package Name="@PRODUCT_NAME@"
     Version="@VERSION@"
     Manufacturer="WSO2"
-    UpgradeCode="344b046a-fa6a-4452-be40-2794f59fe7b0"
+    UpgradeCode="@UPGRADE_CODE@"
     InstallerVersion="500"
     Compressed="yes"
     Scope="perUser"

--- a/installers/windows/build.bat
+++ b/installers/windows/build.bat
@@ -108,10 +108,21 @@ REM sources are backed up and restored via :restore_name on every exit path.
 for /f "delims=" %%p in ('powershell -nologo -noprofile -command "(Get-ChildItem '.\WixPackage\payload\Integrator' -Filter *.exe -File | Select-Object -First 1).BaseName"') do set "PRODUCT_NAME=%%p"
 if not defined PRODUCT_NAME set "PRODUCT_NAME=WSO2 Integrator"
 echo Product name: %PRODUCT_NAME%
+
+REM Each flavor needs its own MSI UpgradeCode and install folder, otherwise
+REM installing one flavor upgrades/replaces the other.
+if "%PRODUCT_NAME%"=="WSO2 Agent Builder" (
+    set "UPGRADE_CODE=56138e5c-e9ef-499b-8a21-54e2cfc09ba3"
+    set "PRODUCT_DIR=Agent Builder"
+) else (
+    set "UPGRADE_CODE=344b046a-fa6a-4452-be40-2794f59fe7b0"
+    set "PRODUCT_DIR=Integrator"
+)
 copy /y ".\WixPackage\Package.wxs" ".\WixPackage\Package.wxs.bak" >nul
 copy /y ".\WixPackage\IntegratorComponents.wxs" ".\WixPackage\IntegratorComponents.wxs.bak" >nul
+copy /y ".\WixPackage\Folders.wxs" ".\WixPackage\Folders.wxs.bak" >nul
 copy /y ".\CustomAction1\CustomAction.cs" ".\CustomAction1\CustomAction.cs.bak" >nul
-powershell -Command "foreach ($f in '.\WixPackage\Package.wxs','.\WixPackage\IntegratorComponents.wxs','.\CustomAction1\CustomAction.cs') { (Get-Content -Raw $f).Replace('@PRODUCT_NAME@', '%PRODUCT_NAME%') | Set-Content $f }"
+powershell -Command "foreach ($f in '.\WixPackage\Package.wxs','.\WixPackage\IntegratorComponents.wxs','.\WixPackage\Folders.wxs','.\CustomAction1\CustomAction.cs') { (Get-Content -Raw $f).Replace('@PRODUCT_NAME@', '%PRODUCT_NAME%').Replace('@UPGRADE_CODE@', '%UPGRADE_CODE%').Replace('@PRODUCT_DIR@', '%PRODUCT_DIR%') | Set-Content $f }"
 
 REM Map build directory to a short drive letter to keep file paths under 260 chars.
 REM wixnative.exe lacks a longPathAware manifest, so it crashes on paths > 260 chars.
@@ -189,5 +200,6 @@ REM version-restore step still applies afterwards.
 :restore_name
 if exist ".\WixPackage\Package.wxs.bak" move /y ".\WixPackage\Package.wxs.bak" ".\WixPackage\Package.wxs" >nul
 if exist ".\WixPackage\IntegratorComponents.wxs.bak" move /y ".\WixPackage\IntegratorComponents.wxs.bak" ".\WixPackage\IntegratorComponents.wxs" >nul
+if exist ".\WixPackage\Folders.wxs.bak" move /y ".\WixPackage\Folders.wxs.bak" ".\WixPackage\Folders.wxs" >nul
 if exist ".\CustomAction1\CustomAction.cs.bak" move /y ".\CustomAction1\CustomAction.cs.bak" ".\CustomAction1\CustomAction.cs" >nul
 exit /b 0


### PR DESCRIPTION
## Problem

An installed **WSO2 Agent Builder** app showed the splash/titles correctly but rendered the **Integrator** Get Started page. Diagnosis on a real install: the extension host was loading a user-installed WI extension from `~/.wso2-integrator/extensions/wso2.wso2-integrator-1.1.26082017` — an older Integrator build with no agent-mode code — which shadowed the app's (correct, current) built-in extension because its version was higher. Root cause: both flavors shared `dataFolderName`, so any WI extension a user installs (or an auto-update/marketplace publish delivers) into one product silently hijacks the other.

Sharing extended beyond the extensions dir: same macOS bundle id and pkg receipts, same Windows mutex (the two apps couldn't run simultaneously), same taskbar identity, same URL protocol (sign-in browser callbacks could reopen the wrong app), and the same MSI `UpgradeCode` — installing one flavor would upgrade/replace the other on Windows.

## Change

The two flavors now keep **all data separate** and install/run side by side:

| Surface | Agent Builder value |
|---|---|
| `dataFolderName` / `sharedDataFolderName` / `serverDataFolderName` | `.wso2-agent-builder`(-shared) |
| `darwinBundleIdentifier` / mac pkg identifier | `com.wso2.agentbuilder` |
| `win32MutexName` / `win32AppUserModelId` / `win32DirName`/`NameVersion` | `wso2-agent-builder` |
| `urlProtocol` | `wso2-agent-builder` (the extension builds callbacks from `vscode.env.uriScheme` — no code change needed) |
| MSI `UpgradeCode` / install dir | `56138e5c-e9ef-499b-8a21-54e2cfc09ba3` / `WSO2\Agent Builder` |

- `ci/build/update-product.sh` derives all of this from `PRODUCT_FLAVOR`.
- Windows: `Package.wxs`/`Folders.wxs` gain `@UPGRADE_CODE@`/`@PRODUCT_DIR@` placeholders, resolved and restored by `build.bat` alongside the existing `@PRODUCT_NAME@` handling.
- macOS: the pkg identifier follows the detected app bundle; `Distribution.xml` uses a `__BUNDLE_ID__` placeholder in the same substitute/restore pattern.

## Still shared by design

`applicationName` and extension/command/view ids (one VSIX serves both flavors), and artifact filenames. **Known gap**: Linux deb/rpm package identity is still shared, so Linux side-by-side installs aren't supported yet.

## Notes for reviewers

- Integrator-flavor output is byte-identical to before (verified by generating both flavors and diffing).
- User-visible consequence for existing agent-builder testers: extensions previously installed under `~/.wso2-integrator` are no longer picked up by Agent Builder (that's the fix); settings/logs were already separate via `nameShort`.
- Needs one CI verification run per flavor; the Windows MSI upgrade/side-by-side behavior is the key thing to check on real hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)