### PR TITLE
Show agents as the first entry in project explorer for agent builder mode

### DIFF
--- a/wi/wi-extension/src/bi/project-explorer/project-explorer-provider.ts
+++ b/wi/wi-extension/src/bi/project-explorer/project-explorer-provider.ts
@@ -34,7 +34,7 @@ import { ballerinaContext } from '../ballerinaContext';
 import { ext } from '../../extensionVariables';
 import { isSamePath } from '../../utils/pathUtils';
 
-import { getExplorerViewId } from '../../productMode';
+import { getExplorerViewId, isAgentBuilderMode } from '../../productMode';
 
 // View ID used for progress indicator
 const EXPLORER_VIEW_ID = getExplorerViewId();
@@ -403,7 +403,11 @@ function getEntriesBI(project: ProjectStructure): ProjectExplorerEntry[] {
     if (agents.children.length > 0) {
         agents.collapsibleState = vscode.TreeItemCollapsibleState.Expanded;
     }
-    entries.push(agents);
+    if (isAgentBuilderMode()) {
+        entries.unshift(agents);
+    } else {
+        entries.push(agents);
+    }
 
     // ---------- Agent Definitions ----------
     const agentDefinitions = new ProjectExplorerEntry(
@@ -420,7 +424,7 @@ function getEntriesBI(project: ProjectStructure): ProjectExplorerEntry[] {
     agentDefinitions.children = getComponents(
         project.directoryMap[DIRECTORY_MAP.AGENT_DEFINITION], DIRECTORY_MAP.AGENT_DEFINITION, projectPath);
     if (agentDefinitions.children.length > 0) {
-        entries.push(agentDefinitions);
+        entries.splice(entries.indexOf(agents) + 1, 0, agentDefinitions);
     }
 
     // ---------- Types ----------


### PR DESCRIPTION
## Purpose

In agent builder mode, the **Agents** section was rendered in its default position within the project explorer. This moves it to the top so agents are the first thing users see, with **Agent Definitions** placed directly after it.

<img width="296" height="296" alt="image" src="https://github.com/user-attachments/assets/1ebe7af3-f9f9-4cc5-9f64-355b3277a68e" />

## Changes

- `wi-extension/src/bi/project-explorer/project-explorer-provider.ts`
  - `unshift` the `Agents` entry instead of `push` when `isAgentBuilderMode()` is true.
  - Insert `Agent Definitions` immediately after `Agents` rather than appending it.

Integrator (non agent-builder) mode ordering is unchanged.