### PR TITLE
fix(ci): derive the signing public key instead of configuring it twice

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1600,7 +1600,7 @@ jobs:
     env:
       # secrets can't be referenced from a step `if:`, so their presence is hoisted here — the same
       # reason HAS_AWS exists on the build jobs.
-      HAS_PINNED_KEY: ${{ secrets.WSO2_UPDATE_PUBLIC_KEY != '' && secrets.COSIGN_PUBLIC_KEY != '' }}
+      HAS_PINNED_KEY: ${{ secrets.WSO2_UPDATE_PUBLIC_KEY != '' }}
       # New builds publish to the channel chosen at dispatch (default insider); the
       # promote-channel workflow later copies a source document down the ladder.
       CHANNEL: ${{ inputs.channel || 'insider' }}
@@ -1691,33 +1691,47 @@ jobs:
         if: ${{ steps.targets.outputs.targets != '' }}
         uses: sigstore/cosign-installer@v3
 
+      # The public half is DERIVED from the signing key rather than configured separately. A second
+      # public-key secret can only agree or disagree with this one, and when it disagreed the
+      # signatures still verified in-run -- so the mismatch that matters (pinned key vs the key that
+      # actually signs) was the one the old check could not see.
+      - name: Derive the signing public key
+        if: ${{ steps.targets.outputs.targets != '' }}
+        run: |
+          set -euo pipefail
+          cosign public-key --key env://COSIGN_PRIVATE_KEY > signing.pub
+          grep -q 'BEGIN PUBLIC KEY' signing.pub
+          echo "derived the public half of COSIGN_PRIVATE_KEY"
+        env:
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+
       # The client verifies artifacts against WSO2_UPDATE_PUBLIC_KEY, baked into product.json at
       # build time; CI signs with COSIGN_PRIVATE_KEY. Nothing downstream compares the two, so if they
       # are not the same key pair every client rejects every artifact — and the signing steps below
-      # still pass, because they verify against COSIGN_PUBLIC_KEY. That failure would only surface on
+      # still pass, because they verify against the signing key itself. That failure would only surface on
       # a user's machine, after the release. One base64 decode catches it here instead.
       - name: Check the pinned key matches the signing key
         if: ${{ steps.targets.outputs.targets != '' && env.HAS_PINNED_KEY == 'true' }}
         run: |
           set -euo pipefail
           printf '%s' "$WSO2_UPDATE_PUBLIC_KEY" | base64 -d > pinned.pem 2>/dev/null || {
-            echo "::error::WSO2_UPDATE_PUBLIC_KEY is not valid base64. It must be 'base64 < cosign.pub'." >&2
+            echo "::error::WSO2_UPDATE_PUBLIC_KEY is not valid base64. It must be 'base64 -w0 < cosign.pub'." >&2
             exit 1
           }
-          printf '%s' "$COSIGN_PUBLIC_KEY" > signing.pem
-          # Compare the DER of each, so PEM line wrapping or a trailing newline cannot fail a
-          # correctly configured pair.
+          # Compared against the key derived from COSIGN_PRIVATE_KEY, so this proves the pinned key
+          # matches the key that actually signs. DER, so PEM wrapping or a trailing newline cannot
+          # fail a correctly configured pair.
           openssl pkey -pubin -in pinned.pem  -outform DER -out pinned.der
-          openssl pkey -pubin -in signing.pem -outform DER -out signing.der
+          openssl pkey -pubin -in signing.pub -outform DER -out signing.der
           if ! cmp -s pinned.der signing.der; then
-            echo "::error::WSO2_UPDATE_PUBLIC_KEY does not match COSIGN_PUBLIC_KEY. Clients built here would reject every artifact this run signs." >&2
+            echo "::error::WSO2_UPDATE_PUBLIC_KEY is not the public half of COSIGN_PRIVATE_KEY. Clients built here would reject every artifact this run signs." >&2
             exit 1
           fi
           echo "Pinned client key matches the signing key."
-          rm -f pinned.pem signing.pem pinned.der signing.der
+          rm -f pinned.pem pinned.der signing.der
         env:
           WSO2_UPDATE_PUBLIC_KEY: ${{ secrets.WSO2_UPDATE_PUBLIC_KEY }}
-          COSIGN_PUBLIC_KEY: ${{ secrets.COSIGN_PUBLIC_KEY }}
 
       - name: Sign source document
         if: ${{ steps.targets.outputs.targets != '' }}
@@ -1729,11 +1743,7 @@ jobs:
       - name: Verify source signature
         if: ${{ steps.targets.outputs.targets != '' }}
         run: |
-          printf '%s' "$COSIGN_PUBLIC_KEY" > cosign.pub
-          cosign verify-blob --key cosign.pub --signature source.json.sig source.json
-          rm -f cosign.pub
-        env:
-          COSIGN_PUBLIC_KEY: ${{ secrets.COSIGN_PUBLIC_KEY }}
+          cosign verify-blob --key signing.pub --signature source.json.sig source.json
 
       - name: Upload source artifact
         if: ${{ steps.targets.outputs.targets != '' }}
@@ -1764,7 +1774,7 @@ jobs:
           fi
           # Public key as a file, matching the source verify step: cosign's env:// keyref is used
           # for the private key, and the proven pattern here for verification is a key file.
-          printf '%s' "$COSIGN_PUBLIC_KEY" > cosign.pub
+
           # Sign the STATEMENTS the generator wrote, not the artifacts themselves. A signature over
           # artifact bytes proves only "WSO2 produced this file", which would leave the document free
           # to offer an old signed artifact under a new version label; the statement binds
@@ -1774,10 +1784,9 @@ jobs:
             cosign sign-blob --key env://COSIGN_PRIVATE_KEY "${file}" --output-signature "${file}.sig" --yes
             # Verify immediately: a signature that cannot be checked here would ship as one the
             # client rejects, turning a signing misconfiguration into a failed update for users.
-            cosign verify-blob --key cosign.pub --signature "${file}.sig" "${file}"
+            cosign verify-blob --key signing.pub --signature "${file}.sig" "${file}"
             echo "signed $(basename "${file}")"
           done
-          rm -f cosign.pub
           # Every mirrored artifact must have one: an unsigned artifact would be served with a
           # statement URL that 404s, which the client treats as a hard failure.
           artifacts=$(find artifacts-mirror -type f ! -name '*.statement.json' ! -name '*.sig' | wc -l | tr -d ' ')
@@ -1790,7 +1799,6 @@ jobs:
         env:
           COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
-          COSIGN_PUBLIC_KEY: ${{ secrets.COSIGN_PUBLIC_KEY }}
 
       - name: Upload mirrored artifacts to update bucket
         if: ${{ steps.targets.outputs.targets != '' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -211,6 +211,46 @@ jobs:
           WSO2_UPDATE_PUBLIC_KEY: ${{ secrets.WSO2_UPDATE_PUBLIC_KEY }}
           COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
 
+      - name: cosign-installer
+        if: ${{ inputs.publish_update_source == true && inputs.build_packed_installers == true && inputs.publish_tag != '' }}
+        uses: sigstore/cosign-installer@v3
+
+      # Presence is not enough: a pinned key from the wrong pair passes every check downstream,
+      # because the signing steps verify against the signing key itself. Only comparing the two
+      # catches it, and it has to happen here — build-macos and build-windows bake the pinned key
+      # into product.json, so a comparison in Publish Update Source runs after the installers that
+      # carry the wrong key already exist. Deriving here also exercises COSIGN_PASSWORD, which
+      # would otherwise fail a full build later.
+      - name: Verify the pinned client key matches the signing key
+        if: ${{ inputs.publish_update_source == true && inputs.build_packed_installers == true && inputs.publish_tag != '' }}
+        run: |
+          set -euo pipefail
+          cosign public-key --key env://COSIGN_PRIVATE_KEY > signing.pub
+          grep -q 'BEGIN PUBLIC KEY' signing.pub
+          printf '%s' "$WSO2_UPDATE_PUBLIC_KEY" | base64 -d > pinned.pem 2>/dev/null || {
+            echo "::error::WSO2_UPDATE_PUBLIC_KEY is not valid base64. It must be 'base64 -w0 < cosign.pub'." >&2
+            exit 1
+          }
+          # base64 -d accepts the empty string, so an empty secret would otherwise reach openssl
+          # and die there with an opaque parse error instead of this one.
+          [ -s pinned.pem ] || {
+            echo "::error::WSO2_UPDATE_PUBLIC_KEY decoded to nothing." >&2
+            exit 1
+          }
+          # DER, so PEM wrapping or a trailing newline cannot fail a correctly configured pair.
+          openssl pkey -pubin -in pinned.pem  -outform DER -out pinned.der
+          openssl pkey -pubin -in signing.pub -outform DER -out signing.der
+          if ! cmp -s pinned.der signing.der; then
+            echo "::error::WSO2_UPDATE_PUBLIC_KEY is not the public half of COSIGN_PRIVATE_KEY. Clients built here would reject every artifact this run signs." >&2
+            exit 1
+          fi
+          echo "pinned client key matches the signing key"
+          rm -f signing.pub pinned.pem pinned.der signing.der
+        env:
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+          WSO2_UPDATE_PUBLIC_KEY: ${{ secrets.WSO2_UPDATE_PUBLIC_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -1731,33 +1771,6 @@ jobs:
           COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
 
-      # The client verifies artifacts against WSO2_UPDATE_PUBLIC_KEY, baked into product.json at
-      # build time; CI signs with COSIGN_PRIVATE_KEY. Nothing downstream compares the two, so if they
-      # are not the same key pair every client rejects every artifact — and the signing steps below
-      # still pass, because they verify against the signing key itself. That failure would only surface on
-      # a user's machine, after the release. One base64 decode catches it here instead.
-      - name: Check the pinned key matches the signing key
-        if: ${{ steps.targets.outputs.targets != '' }}
-        run: |
-          set -euo pipefail
-          printf '%s' "$WSO2_UPDATE_PUBLIC_KEY" | base64 -d > pinned.pem 2>/dev/null || {
-            echo "::error::WSO2_UPDATE_PUBLIC_KEY is not valid base64. It must be 'base64 -w0 < cosign.pub'." >&2
-            exit 1
-          }
-          # Compared against the key derived from COSIGN_PRIVATE_KEY, so this proves the pinned key
-          # matches the key that actually signs. DER, so PEM wrapping or a trailing newline cannot
-          # fail a correctly configured pair.
-          openssl pkey -pubin -in pinned.pem  -outform DER -out pinned.der
-          openssl pkey -pubin -in signing.pub -outform DER -out signing.der
-          if ! cmp -s pinned.der signing.der; then
-            echo "::error::WSO2_UPDATE_PUBLIC_KEY is not the public half of COSIGN_PRIVATE_KEY. Clients built here would reject every artifact this run signs." >&2
-            exit 1
-          fi
-          echo "Pinned client key matches the signing key."
-          rm -f pinned.pem pinned.der signing.der
-        env:
-          WSO2_UPDATE_PUBLIC_KEY: ${{ secrets.WSO2_UPDATE_PUBLIC_KEY }}
-
       - name: Sign source document
         if: ${{ steps.targets.outputs.targets != '' }}
         run: cosign sign-blob --key env://COSIGN_PRIVATE_KEY source.json --output-signature source.json.sig --yes
@@ -1797,9 +1810,6 @@ jobs:
             echo "No mirrored artifacts to sign."
             exit 0
           fi
-          # Public key as a file, matching the source verify step: cosign's env:// keyref is used
-          # for the private key, and the proven pattern here for verification is a key file.
-
           # Sign the STATEMENTS the generator wrote, not the artifacts themselves. A signature over
           # artifact bytes proves only "WSO2 produced this file", which would leave the document free
           # to offer an old signed artifact under a new version label; the statement binds

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,6 +183,32 @@ jobs:
       integrator_version: ${{ steps.read-versions.outputs.integrator_version }}
       ballerina_jre_version: ${{ steps.read-versions.outputs.ballerina_jre_version }}
     steps:
+      # Checked here rather than in Publish Update Source, because build-macos and build-windows
+      # bake WSO2_UPDATE_URL and WSO2_UPDATE_PUBLIC_KEY into product.json long before that job
+      # runs. A late check cannot stop a run from shipping installers that pin no key and skip
+      # signature verification; this one can, and it costs seconds instead of a full build.
+      - name: Check the publish path is configured
+        if: ${{ inputs.publish_update_source == true }}
+        run: |
+          set -euo pipefail
+          missing=()
+          [ -n "${AWS_UPDATE_S3_BUCKET}" ] || missing+=("AWS_UPDATE_S3_BUCKET")
+          [ -n "${WSO2_UPDATE_ARTIFACTS_URL}" ] || missing+=("WSO2_UPDATE_ARTIFACTS_URL (artifacts must be mirrored; clients refuse upstream hosts)")
+          [ -n "${WSO2_UPDATE_URL}" ] || missing+=("WSO2_UPDATE_URL (clients built here would have no update endpoint)")
+          [ -n "${WSO2_UPDATE_PUBLIC_KEY}" ] || missing+=("WSO2_UPDATE_PUBLIC_KEY (clients built here would pin no key and accept unverified artifacts)")
+          [ -n "${COSIGN_PRIVATE_KEY}" ] || missing+=("COSIGN_PRIVATE_KEY")
+          if [ ${#missing[@]} -gt 0 ]; then
+            printf '::error::missing required secret: %s\n' "${missing[@]}" >&2
+            exit 1
+          fi
+          echo "publish path configured for channel ${{ inputs.channel || 'insider' }}"
+        env:
+          AWS_UPDATE_S3_BUCKET: ${{ secrets.AWS_UPDATE_S3_BUCKET }}
+          WSO2_UPDATE_ARTIFACTS_URL: ${{ secrets.WSO2_UPDATE_ARTIFACTS_URL }}
+          WSO2_UPDATE_URL: ${{ secrets.WSO2_UPDATE_URL }}
+          WSO2_UPDATE_PUBLIC_KEY: ${{ secrets.WSO2_UPDATE_PUBLIC_KEY }}
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -1598,9 +1624,6 @@ jobs:
       id-token: write
       contents: read
     env:
-      # secrets can't be referenced from a step `if:`, so their presence is hoisted here — the same
-      # reason HAS_AWS exists on the build jobs.
-      HAS_PINNED_KEY: ${{ secrets.WSO2_UPDATE_PUBLIC_KEY != '' }}
       # New builds publish to the channel chosen at dispatch (default insider); the
       # promote-channel workflow later copies a source document down the ladder.
       CHANNEL: ${{ inputs.channel || 'insider' }}
@@ -1712,7 +1735,7 @@ jobs:
       # still pass, because they verify against the signing key itself. That failure would only surface on
       # a user's machine, after the release. One base64 decode catches it here instead.
       - name: Check the pinned key matches the signing key
-        if: ${{ steps.targets.outputs.targets != '' && env.HAS_PINNED_KEY == 'true' }}
+        if: ${{ steps.targets.outputs.targets != '' }}
         run: |
           set -euo pipefail
           printf '%s' "$WSO2_UPDATE_PUBLIC_KEY" | base64 -d > pinned.pem 2>/dev/null || {

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -187,8 +187,10 @@ jobs:
       # bake WSO2_UPDATE_URL and WSO2_UPDATE_PUBLIC_KEY into product.json long before that job
       # runs. A late check cannot stop a run from shipping installers that pin no key and skip
       # signature verification; this one can, and it costs seconds instead of a full build.
+      # Conditions mirror the Publish Update Source job's own `if:`, so a run that would not
+      # publish anyway is never failed for missing publish secrets.
       - name: Check the publish path is configured
-        if: ${{ inputs.publish_update_source == true }}
+        if: ${{ inputs.publish_update_source == true && inputs.build_packed_installers == true && inputs.publish_tag != '' }}
         run: |
           set -euo pipefail
           missing=()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -195,6 +195,8 @@ jobs:
           set -euo pipefail
           missing=()
           [ -n "${AWS_UPDATE_S3_BUCKET}" ] || missing+=("AWS_UPDATE_S3_BUCKET")
+          [ -n "${AWS_ACCESS_KEY_ID}" ] || missing+=("AWS_ACCESS_KEY_ID (nothing could be uploaded to the update bucket)")
+          [ -n "${AWS_SECRET_ACCESS_KEY}" ] || missing+=("AWS_SECRET_ACCESS_KEY")
           [ -n "${WSO2_UPDATE_ARTIFACTS_URL}" ] || missing+=("WSO2_UPDATE_ARTIFACTS_URL (artifacts must be mirrored; clients refuse upstream hosts)")
           [ -n "${WSO2_UPDATE_URL}" ] || missing+=("WSO2_UPDATE_URL (clients built here would have no update endpoint)")
           [ -n "${WSO2_UPDATE_PUBLIC_KEY}" ] || missing+=("WSO2_UPDATE_PUBLIC_KEY (clients built here would pin no key and accept unverified artifacts)")
@@ -206,6 +208,8 @@ jobs:
           echo "publish path configured for channel ${{ inputs.channel || 'insider' }}"
         env:
           AWS_UPDATE_S3_BUCKET: ${{ secrets.AWS_UPDATE_S3_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           WSO2_UPDATE_ARTIFACTS_URL: ${{ secrets.WSO2_UPDATE_ARTIFACTS_URL }}
           WSO2_UPDATE_URL: ${{ secrets.WSO2_UPDATE_URL }}
           WSO2_UPDATE_PUBLIC_KEY: ${{ secrets.WSO2_UPDATE_PUBLIC_KEY }}

--- a/.github/workflows/publish-components.yml
+++ b/.github/workflows/publish-components.yml
@@ -71,11 +71,10 @@ jobs:
       CHANNEL: ${{ inputs.channel }}
       BUCKET: ${{ secrets.AWS_UPDATE_S3_BUCKET }}
       ARTIFACTS_URL: ${{ secrets.WSO2_UPDATE_ARTIFACTS_URL }}
-      # A step `if:` cannot see `secrets`, so presence is hoisted to job env.
-      HAS_PINNED_KEY: ${{ secrets.WSO2_UPDATE_PUBLIC_KEY != '' }}
     steps:
-      # Checked before the build rather than after it. All three are required: without mirroring or
-      # signing, the resulting document is one every client rejects.
+      # Checked before the build rather than after it. All four are required: without mirroring or
+      # signing, the resulting document is one every client rejects, and without the pinned key
+      # nothing proves the signature matches what released clients actually verify against.
       - name: Check the publish path is configured
         run: |
           set -euo pipefail
@@ -83,6 +82,7 @@ jobs:
           [ -n "${BUCKET}" ] || missing+=("AWS_UPDATE_S3_BUCKET")
           [ -n "${ARTIFACTS_URL}" ] || missing+=("WSO2_UPDATE_ARTIFACTS_URL (components must be mirrored; clients refuse upstream hosts)")
           [ -n "${COSIGN_PRIVATE_KEY}" ] || missing+=("COSIGN_PRIVATE_KEY")
+          [ -n "${WSO2_UPDATE_PUBLIC_KEY}" ] || missing+=("WSO2_UPDATE_PUBLIC_KEY (nothing would prove the signature matches the key released clients pin)")
           if [ ${#missing[@]} -gt 0 ]; then
             printf '::error::missing required secret: %s\n' "${missing[@]}" >&2
             exit 1
@@ -90,6 +90,7 @@ jobs:
           echo "publish path configured for channel ${CHANNEL}"
         env:
           COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+          WSO2_UPDATE_PUBLIC_KEY: ${{ secrets.WSO2_UPDATE_PUBLIC_KEY }}
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -322,7 +323,7 @@ jobs:
       # is what proves the two are the same pair — a mismatch rejects every artifact, on the user's
       # machine, after release.
       - name: Check the pinned key matches the signing key
-        if: ${{ !inputs.dry_run && env.HAS_PINNED_KEY == 'true' }}
+        if: ${{ !inputs.dry_run }}
         env:
           WSO2_UPDATE_PUBLIC_KEY: ${{ secrets.WSO2_UPDATE_PUBLIC_KEY }}
         run: |

--- a/.github/workflows/publish-components.yml
+++ b/.github/workflows/publish-components.yml
@@ -74,7 +74,7 @@ jobs:
       # A step `if:` cannot see `secrets`, so presence is hoisted to job env.
       HAS_PINNED_KEY: ${{ secrets.WSO2_UPDATE_PUBLIC_KEY != '' }}
     steps:
-      # Checked before the build rather than after it. All four are required: without mirroring or
+      # Checked before the build rather than after it. All three are required: without mirroring or
       # signing, the resulting document is one every client rejects.
       - name: Check the publish path is configured
         run: |
@@ -83,7 +83,6 @@ jobs:
           [ -n "${BUCKET}" ] || missing+=("AWS_UPDATE_S3_BUCKET")
           [ -n "${ARTIFACTS_URL}" ] || missing+=("WSO2_UPDATE_ARTIFACTS_URL (components must be mirrored; clients refuse upstream hosts)")
           [ -n "${COSIGN_PRIVATE_KEY}" ] || missing+=("COSIGN_PRIVATE_KEY")
-          [ -n "${COSIGN_PUBLIC_KEY}" ] || missing+=("COSIGN_PUBLIC_KEY")
           if [ ${#missing[@]} -gt 0 ]; then
             printf '::error::missing required secret: %s\n' "${missing[@]}" >&2
             exit 1
@@ -91,7 +90,6 @@ jobs:
           echo "publish path configured for channel ${CHANNEL}"
         env:
           COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
-          COSIGN_PUBLIC_KEY: ${{ secrets.COSIGN_PUBLIC_KEY }}
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -306,28 +304,41 @@ jobs:
         if: ${{ !inputs.dry_run }}
         uses: sigstore/cosign-installer@v3
 
+      # Derived from the signing key, not configured separately: a second public-key secret could
+      # only agree or disagree with this one, and a disagreement still verified in-run.
+      - name: Derive the signing public key
+        if: ${{ !inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          cosign public-key --key env://COSIGN_PRIVATE_KEY > signing.pub
+          grep -q 'BEGIN PUBLIC KEY' signing.pub
+          echo "derived the public half of COSIGN_PRIVATE_KEY"
+        env:
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+
       # Clients verify against WSO2_UPDATE_PUBLIC_KEY baked into product.json; CI signs with
-      # COSIGN_PRIVATE_KEY. Nothing else compares them, and a mismatch rejects every artifact.
+      # COSIGN_PRIVATE_KEY. Comparing the pinned key against the key DERIVED from the private one
+      # is what proves the two are the same pair — a mismatch rejects every artifact, on the user's
+      # machine, after release.
       - name: Check the pinned key matches the signing key
         if: ${{ !inputs.dry_run && env.HAS_PINNED_KEY == 'true' }}
         env:
           WSO2_UPDATE_PUBLIC_KEY: ${{ secrets.WSO2_UPDATE_PUBLIC_KEY }}
-          COSIGN_PUBLIC_KEY: ${{ secrets.COSIGN_PUBLIC_KEY }}
         run: |
           set -euo pipefail
           printf '%s' "$WSO2_UPDATE_PUBLIC_KEY" | base64 -d > pinned.pem 2>/dev/null || {
-            echo "::error::WSO2_UPDATE_PUBLIC_KEY is not valid base64. It must be 'base64 < cosign.pub'." >&2
+            echo "::error::WSO2_UPDATE_PUBLIC_KEY is not valid base64. It must be 'base64 -w0 < cosign.pub'." >&2
             exit 1
           }
-          printf '%s' "$COSIGN_PUBLIC_KEY" > signing.pem
           openssl pkey -pubin -in pinned.pem  -outform DER -out pinned.der
-          openssl pkey -pubin -in signing.pem -outform DER -out signing.der
+          openssl pkey -pubin -in signing.pub -outform DER -out signing.der
           if ! cmp -s pinned.der signing.der; then
-            echo "::error::WSO2_UPDATE_PUBLIC_KEY does not match COSIGN_PUBLIC_KEY. Clients would reject every artifact this run signs." >&2
+            echo "::error::WSO2_UPDATE_PUBLIC_KEY is not the public half of COSIGN_PRIVATE_KEY. Clients would reject every artifact this run signs." >&2
             exit 1
           fi
           echo "Pinned client key matches the signing key."
-          rm -f pinned.pem signing.pem pinned.der signing.der
+          rm -f pinned.pem pinned.der signing.der
 
       - name: Sign source document
         if: ${{ !inputs.dry_run }}
@@ -338,12 +349,8 @@ jobs:
 
       - name: Verify source signature
         if: ${{ !inputs.dry_run }}
-        env:
-          COSIGN_PUBLIC_KEY: ${{ secrets.COSIGN_PUBLIC_KEY }}
         run: |
-          printf '%s' "$COSIGN_PUBLIC_KEY" > cosign.pub
-          cosign verify-blob --key cosign.pub --signature source.json.sig source.json
-          rm -f cosign.pub
+          cosign verify-blob --key signing.pub --signature source.json.sig source.json
 
       # Statements, not artifact bytes: signing bytes alone would let a document offer an old
       # artifact under a new version label. The statement binds id + version + sha256 + requires.
@@ -352,7 +359,6 @@ jobs:
         env:
           COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
-          COSIGN_PUBLIC_KEY: ${{ secrets.COSIGN_PUBLIC_KEY }}
         run: |
           set -euo pipefail
           if [ ! -d artifacts-mirror ]; then
@@ -365,13 +371,11 @@ jobs:
             echo "::error::no artifacts-mirror directory, but this document names artifacts the current one does not; it would point at URLs with no bytes behind them." >&2
             exit 1
           fi
-          printf '%s' "$COSIGN_PUBLIC_KEY" > cosign.pub
           find artifacts-mirror -type f -name '*.statement.json' -print0 | while IFS= read -r -d '' file; do
             cosign sign-blob --key env://COSIGN_PRIVATE_KEY "${file}" --output-signature "${file}.sig" --yes
-            cosign verify-blob --key cosign.pub --signature "${file}.sig" "${file}"
+            cosign verify-blob --key signing.pub --signature "${file}.sig" "${file}"
             echo "signed $(basename "${file}")"
           done
-          rm -f cosign.pub
           artifacts=$(find artifacts-mirror -type f ! -name '*.statement.json' ! -name '*.sig' | wc -l | tr -d ' ')
           statements=$(find artifacts-mirror -type f -name '*.statement.json' | wc -l | tr -d ' ')
           echo "artifacts=${artifacts} statements=${statements}"

--- a/.github/workflows/publish-components.yml
+++ b/.github/workflows/publish-components.yml
@@ -332,6 +332,12 @@ jobs:
             echo "::error::WSO2_UPDATE_PUBLIC_KEY is not valid base64. It must be 'base64 -w0 < cosign.pub'." >&2
             exit 1
           }
+          # base64 -d accepts the empty string, so an empty secret would otherwise reach openssl
+          # and die there with an opaque parse error instead of this one.
+          [ -s pinned.pem ] || {
+            echo "::error::WSO2_UPDATE_PUBLIC_KEY decoded to nothing." >&2
+            exit 1
+          }
           openssl pkey -pubin -in pinned.pem  -outform DER -out pinned.der
           openssl pkey -pubin -in signing.pub -outform DER -out signing.der
           if ! cmp -s pinned.der signing.der; then


### PR DESCRIPTION
## Purpose

Two changes to how the update-signing keys are configured and checked. Both concern the same failure: CI signing with one key while released clients pin another.

### 1. Derive the signing public key instead of configuring it twice

`COSIGN_PUBLIC_KEY` was a second secret holding the public half of `COSIGN_PRIVATE_KEY`. It can only agree or disagree with the private key, and when it disagreed the run still passed — every signature verified against `COSIGN_PUBLIC_KEY`, which is exactly the key that was wrong. The check could not see the mismatch that matters.

Both workflows now derive it:

```yaml
cosign public-key --key env://COSIGN_PRIVATE_KEY > signing.pub
grep -q 'BEGIN PUBLIC KEY' signing.pub
```

`WSO2_UPDATE_PUBLIC_KEY` is compared against that derived key, so the comparison proves the pinned key matches the key that actually signs. `COSIGN_PUBLIC_KEY` is dropped from both workflows and can be deleted from the repository secrets once this merges.

### 2. Check the publish path before the builds run, not after

`WSO2_UPDATE_PUBLIC_KEY` was optional, and its absence was silent in the worst direction: the comparison was skipped and `WSO2_UPDATE_REQUIRE_ARTIFACT_SIGNATURE` computed to `false`, so a green release shipped clients that pin no key and accept unverified artifacts, then published a source document for them.

`resolve-versions` now gates the run. It is the right place because `build-macos` and `build-windows` bake `WSO2_UPDATE_URL` and `WSO2_UPDATE_PUBLIC_KEY` into `product.json` via `update-product.sh`. A check in `publish-update-source` runs after those installers exist; all it can do is decline to publish a document for them. Two steps, both gated on the same conditions as `publish-update-source`'s own `if:` (`publish_update_source && build_packed_installers && publish_tag != ''`), so a run that would not publish is never failed for missing publish secrets:

- **Check the publish path is configured** — `AWS_UPDATE_S3_BUCKET`, `WSO2_UPDATE_ARTIFACTS_URL`, `WSO2_UPDATE_URL`, `WSO2_UPDATE_PUBLIC_KEY`, `COSIGN_PRIVATE_KEY` are present.
- **Verify the pinned client key matches the signing key** — derives from `COSIGN_PRIVATE_KEY` and compares in DER. Presence alone would leave the wrong-pair case to the late check; this also exercises `COSIGN_PASSWORD`, which otherwise burns a full build before failing at the derive step.

The comparison in `publish-update-source` is now redundant and removed. That job still derives `signing.pub` for signature verification.

`publish-components.yml` is a single job with no earlier phase, so its own preflight gained `WSO2_UPDATE_PUBLIC_KEY` and its comparison is likewise unconditional (still skipped on `dry_run`).

## Effect on existing builds

`dev-build.yml` and `daily-build.yml` never pass `publish_update_source`, so it defaults to `false` and both new steps are skipped — those builds still run with no update secrets at all. Only `release.yml`, which defaults it to `true`, reaches them.

## Verification

Two throwaway cosign keypairs, against the real step scripts:

| Case | Result |
|---|---|
| Pinned key is the public half of the signing key | passes |
| Pinned key is from the **other** pair | refused — the case the old public-vs-public check structurally could not see |
| Pinned key empty | refused by the `[ -s pinned.pem ]` guard, rather than dying at `openssl` with a parse error |
| Pinned key not valid base64 | refused |

The derived PEM is DER-identical to the `cosign.pub` that `cosign generate-key-pair` writes, so no re-keying is needed. Both workflows parse under `YAML.safe_load`, and the preflight exits 1 listing exactly the missing secret names and 0 when complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved signing verification for published updates and components by deriving the verification key from the configured private key.
  * Added early validation for required publishing configuration and ensured the pinned update key matches the signing key.
  * Applied consistent signature verification to source documents and mirrored artifacts.
  * Removed the need for a separately configured public-key secret.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->