### PR TITLE
fix(ci): drop the retired installer bucket and restore the update-bucket login

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -285,11 +285,6 @@ jobs:
     name: Build (macOS)
     runs-on: ${{ matrix.runner }}
     needs: [resolve-versions, compile]
-    env:
-      # secrets can't be referenced from a step `if:`, so their presence is hoisted here. Both are
-      # needed to publish the Squirrel.Mac payload: credentials to write, and a bucket to write to.
-      HAS_AWS: ${{ secrets.AWS_ACCESS_KEY_ID != '' }}
-      HAS_UPDATE_BUCKET: ${{ secrets.AWS_UPDATE_S3_BUCKET != '' }}
     defaults:
       run:
         working-directory: lib/vscode
@@ -757,31 +752,41 @@ jobs:
             xcrun stapler staple "$ARTIFACT"
           done
 
-      # Only the two steps below touch AWS in this job, and only on a publishing release, so the
-      # credentials are configured immediately before the upload rather than for the whole job.
-      - name: Configure AWS credentials for the update bucket
-        if: ${{ inputs.publish_update_source == true && inputs.build_packed_installers == true && env.HAS_AWS == 'true' && env.HAS_UPDATE_BUCKET == 'true' }}
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION || 'us-east-1' }}
-
+      # This is the only AWS consumer in the job, so the credentials go in its own `env:` rather
+      # than through configure-aws-credentials, which writes them to $GITHUB_ENV and would leave
+      # live S3 write credentials in scope for every step that follows.
+      #
+      # It fails rather than skips on a half-configured run: publish-update-source embeds
+      # app.squirrel.url into the darwin manifest regardless, so skipping here would ship a
+      # manifest pointing at an object nobody uploaded — a 404 for every macOS client at apply
+      # time, from a green build.
       - name: Publish Squirrel.Mac update payload to update bucket
-        if: ${{ inputs.publish_update_source == true && inputs.build_packed_installers == true && env.HAS_AWS == 'true' && env.HAS_UPDATE_BUCKET == 'true' }}
+        if: ${{ inputs.publish_update_source == true && inputs.build_packed_installers == true }}
         working-directory: .
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION || 'us-east-1' }}
+          AWS_UPDATE_S3_BUCKET: ${{ secrets.AWS_UPDATE_S3_BUCKET }}
         run: |
+          set -euo pipefail
+          missing=()
+          [ -n "${AWS_UPDATE_S3_BUCKET}" ] || missing+=("AWS_UPDATE_S3_BUCKET")
+          [ -n "${AWS_ACCESS_KEY_ID}" ] || missing+=("AWS_ACCESS_KEY_ID")
+          [ -n "${AWS_SECRET_ACCESS_KEY}" ] || missing+=("AWS_SECRET_ACCESS_KEY")
+          if [ ${#missing[@]} -gt 0 ]; then
+            printf '::error::missing required secret: %s\n' "${missing[@]}" >&2
+            exit 1
+          fi
           V="${{ needs.resolve-versions.outputs.integrator_version }}"
           ZIP="installers/mac/wso2-integrator-${V}-${{ matrix.arch }}-mac.zip"
-          # The step only runs when this build publishes updates, so a missing payload is the
-          # failure it looks like rather than a deployment that simply uploads nothing.
           if [ ! -f "$ZIP" ]; then
-            echo "Squirrel.Mac payload not found at $ZIP" >&2
+            echo "::error::Squirrel.Mac payload not found at $ZIP" >&2
             exit 1
           fi
           # Same artifacts layout as everything else; the darwin manifest's app.squirrel.url
           # (embedded by generate-update-manifest.mjs) points at this exact versioned CDN URL.
-          DEST="s3://${{ secrets.AWS_UPDATE_S3_BUCKET }}/artifacts/app/${V}/"
+          DEST="s3://${AWS_UPDATE_S3_BUCKET}/artifacts/app/${V}/"
           aws s3 cp "$ZIP" "${DEST}wso2-integrator-${V}-${{ matrix.arch }}-mac.zip" --content-type application/zip --cache-control no-cache
           echo "Published Squirrel.Mac payload for darwin/${{ matrix.arch }} (v${V})"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -286,10 +286,10 @@ jobs:
     runs-on: ${{ matrix.runner }}
     needs: [resolve-versions, compile]
     env:
-      # secrets can't be referenced from a step `if:`. HAS_AWS says credentials exist;
-      # HAS_INSTALLER_BUCKET says a target bucket does. They are different secrets.
+      # secrets can't be referenced from a step `if:`, so their presence is hoisted here. Both are
+      # needed to publish the Squirrel.Mac payload: credentials to write, and a bucket to write to.
       HAS_AWS: ${{ secrets.AWS_ACCESS_KEY_ID != '' }}
-      HAS_INSTALLER_BUCKET: ${{ secrets.AWS_S3_BUCKET != '' }}
+      HAS_UPDATE_BUCKET: ${{ secrets.AWS_UPDATE_S3_BUCKET != '' }}
     defaults:
       run:
         working-directory: lib/vscode
@@ -756,18 +756,25 @@ jobs:
               --wait
             xcrun stapler staple "$ARTIFACT"
           done
+
+      # Only the two steps below touch AWS in this job, and only on a publishing release, so the
+      # credentials are configured immediately before the upload rather than for the whole job.
+      - name: Configure AWS credentials for the update bucket
+        if: ${{ inputs.publish_update_source == true && inputs.build_packed_installers == true && env.HAS_AWS == 'true' && env.HAS_UPDATE_BUCKET == 'true' }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION || 'us-east-1' }}
+
       - name: Publish Squirrel.Mac update payload to update bucket
-        if: ${{ inputs.build_packed_installers == true && env.HAS_AWS == 'true' }}
+        if: ${{ inputs.publish_update_source == true && inputs.build_packed_installers == true && env.HAS_AWS == 'true' && env.HAS_UPDATE_BUCKET == 'true' }}
         working-directory: .
         run: |
           V="${{ needs.resolve-versions.outputs.integrator_version }}"
           ZIP="installers/mac/wso2-integrator-${V}-${{ matrix.arch }}-mac.zip"
-          # Bucket first: a deployment that publishes no updates skips cleanly here, and only a
-          # deployment that WOULD upload treats a missing payload as the failure it is.
-          if [ -z "${{ secrets.AWS_UPDATE_S3_BUCKET }}" ]; then
-            echo "AWS_UPDATE_S3_BUCKET not set — skipping Squirrel.Mac payload upload."
-            exit 0
-          fi
+          # The step only runs when this build publishes updates, so a missing payload is the
+          # failure it looks like rather than a deployment that simply uploads nothing.
           if [ ! -f "$ZIP" ]; then
             echo "Squirrel.Mac payload not found at $ZIP" >&2
             exit 1
@@ -827,11 +834,6 @@ jobs:
     name: Build (Windows)
     runs-on: windows-2022
     needs: [resolve-versions, compile]
-    env:
-      # secrets can't be referenced from a step `if:`. HAS_AWS says credentials exist;
-      # HAS_INSTALLER_BUCKET says a target bucket does. They are different secrets.
-      HAS_AWS: ${{ secrets.AWS_ACCESS_KEY_ID != '' }}
-      HAS_INSTALLER_BUCKET: ${{ secrets.AWS_S3_BUCKET != '' }}
     defaults:
       run:
         working-directory: lib/vscode


### PR DESCRIPTION
## Purpose

Two loose ends left by the merge of the update mechanism on top of upstream's removal of the old S3 installer uploads.

### 1. `AWS_S3_BUCKET` is dead config

`AWS_S3_BUCKET` was the **old installer bucket**. Upstream's `f7917ab` ("Remove uploading artifacts to aws s3 and aws tool calls in the code-build") removed the steps that wrote to it. What survived is `HAS_INSTALLER_BUCKET`, computed in the macOS and Windows job env blocks and read by **nothing**:

```
$ git grep -n HAS_INSTALLER_BUCKET
.github/workflows/build.yml:292:      HAS_INSTALLER_BUCKET: ${{ secrets.AWS_S3_BUCKET != '' }}
.github/workflows/build.yml:834:      HAS_INSTALLER_BUCKET: ${{ secrets.AWS_S3_BUCKET != '' }}
```

Installers now ship as GitHub release assets, and every remaining `aws s3` call in the repo targets `AWS_UPDATE_S3_BUCKET`. Removed both, plus the Windows job's `HAS_AWS` — that job no longer touches AWS at all.

### 2. The macOS Squirrel upload had no credentials — a real break

`f7917ab` also removed **both** `Login to AWS` steps. The update-mechanism merge restored only the one in `Publish Update Source`. The macOS *Publish Squirrel.Mac update payload* step (added while the mac job still had a login) was therefore running `aws s3 cp` with nothing configured:

- on a publishing release, `Unable to locate credentials` fails the macOS build job;
- the darwin manifest's `app.squirrel.url` — embedded by `generate-update-manifest.mjs` — would point at an object that was never uploaded, so macOS app updates would 404 at apply time.

This PR configures the credentials immediately before that upload (same region resolution as the publish job), rather than for the whole job, since those two steps are the only AWS consumers in it.

### 3. Tightened the gate

Both steps are now gated on `publish_update_source == true` and on the update bucket being configured, which replaces the in-script `-z` bucket check. Nothing writes to the update bucket unless the run is a release that publishes updates — `release.yml` defaults it to `true`, `dev-build.yml` and `daily-build.yml` don't pass it, so they get `false`.

## Secrets impact

`AWS_S3_BUCKET` can be **deleted** from the repository secrets after this merges. `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` must be the credentials for the **update** bucket — they need `s3:GetObject` and `s3:PutObject` on `manifests/*` and `artifacts/*` there.

## Verification

- `YAML.safe_load` parses the workflow; `build-macos.env` is `{HAS_AWS, HAS_UPDATE_BUCKET}` and `build-windows` no longer has an `env` key.
- `git grep AWS_S3_BUCKET` (excluding `AWS_UPDATE_S3_BUCKET`) returns nothing repo-wide.
- The only two AWS-touching steps in `build-macos` are the new login and the Squirrel upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Build and Release**
  - macOS update payload publishing now follows the configured update-source setting alongside packed-installer builds.
  - Builds now report a failure when required publishing credentials are missing, instead of silently skipping the update upload.
  - Updated build configuration applies consistent handling of publishing-related settings across macOS and Windows packaging jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->