### PR TITLE
fix(update): stop offering a Linux app update that is never built

### DIFF
--- a/ci/build/update-manifest.config.json
+++ b/ci/build/update-manifest.config.json
@@ -23,8 +23,7 @@
     "installers": {
       "darwin-arm64": "wso2-integrator-{version}-arm64.dmg",
       "darwin-x64": "wso2-integrator-{version}-x64.dmg",
-      "win32-x64": "wso2-integrator-{version}-update.msi",
-      "linux-x64": "wso2-integrator_{version}_amd64-update.deb"
+      "win32-x64": "wso2-integrator-{version}-update.msi"
     },
     "squirrel": {
       "darwin-arm64": "wso2-integrator-{version}-arm64-mac.zip",


### PR DESCRIPTION
## Problem

A publishing release cannot complete. `publish-update-source` fails in `generate-update-manifest.mjs` before it writes anything.

`build_linux` defaults to `true` in `build.yml`, `release.yml` and `dev-build.yml`, and is hardcoded `true` in `daily-build.yml`, so `linux-x64` always lands in the published targets. The manifest config then asks for an installer that nothing builds:

```json
"linux-x64": "wso2-integrator_{version}_amd64-update.deb"
```

Windows builds an editor-only installer alongside the full one (`INSTALLER_PROFILE=editor-update` → `wso2-integrator-<v>-update.msi`, build.yml:1306-1310) and macOS has its Squirrel payload, but Linux only ever gets the full `.deb` from `compile.yml`. The assets on v5.0.0 show it — `wso2-integrator_5.0.0_amd64.deb`, with no `-update` variant.

The generator has to download each app installer to compute its `sha256` and mirror the bytes, so this isn't a dangling URL in the output — it's a 404 that throws and fails the job.

Loud rather than silent, which is the right direction, but it blocks every release that publishes updates. Daily and dev builds are unaffected: they set `build_linux: true` but never publish.

## Change

Drop the `linux-x64` entry from `app.installers`. That's sufficient on its own — the app loop skips a target with no installer name:

```js
const installerName = installerNames[target];
if (!installerName) {
  continue; // no core-app installer published for this target
}
```

`linux-x64` deliberately **stays** in `targets` and `platformTokens`. `compile.yml` runs `update-product.sh`, so the Linux `.deb`/`.rpm` carry the update endpoint and pinned key and do poll the server. Their component artifacts — the Ballerina distribution, the JRE, the extension VSIXs — all exist upstream and mirror fine. Only the core-app update is unavailable, so Linux clients keep getting component updates and are simply never offered an app update.

Removing `linux-x64` from `targets` instead would have traded one hard failure for another: the workflow still passes it in `--targets`, and the generator rejects targets missing from `config.targets`.

## Verification

Structure-only run with all four targets requested:

```
node ci/build/generate-update-manifest.mjs \
  --targets darwin-arm64,darwin-x64,win32-x64,linux-x64 \
  --sequence 1 --app-version 5.1.0 \
  --app-release-base .../releases/download/v5.1.0 \
  --artifacts-base https://updates.wso2.com/artifacts \
  --no-download --out src.json
```

```
Wrote src.json (9 components x 4 targets, 1 app entries)
  app 5.1.0 targets: darwin-arm64, darwin-x64, win32-x64
  components carrying linux-x64: 9 of 9
  any linux app installer: false
```

No attempt to resolve a Linux `.deb`, all nine components still cover `linux-x64`.

## Restoring it

One line, once an `editor-update` `.deb` is built the way Windows builds its MSI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the Linux x64 installer from the available installer configuration.
  * Updated installer configuration formatting for the Windows x64 entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->