### PR TITLE
[staging/5.1.0] feat(macos): Developer ID signing and notarization for the macOS build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -547,6 +547,76 @@ jobs:
           mkdir -p ../artifacts
           (cd .. && zip -qry "artifacts/VSCode-darwin-${{ matrix.arch }}.zip" VSCode-darwin-${{ matrix.arch }})
           cp ../artifacts/VSCode-darwin-${{ matrix.arch }}.zip ../../installers/mac/
+      # Imports the Developer ID Application cert (codesign: app bundles + DMG) and the
+      # Developer ID Installer cert (productbuild: the .pkg — an unsigned pkg cannot be
+      # notarized) into a temp keychain, then derives the identity names from the imported
+      # certs so no separate identity secret is needed.
+      - name: Import signing certificates (macOS)
+        if: ${{ inputs.build_packed_installers == true }}
+        env:
+          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+          MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+          MACOS_INSTALLER_CERTIFICATE: ${{ secrets.MACOS_INSTALLER_CERTIFICATE }}
+          MACOS_INSTALLER_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_INSTALLER_CERTIFICATE_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          if [ -z "$MACOS_CERTIFICATE" ]; then
+            echo "MACOS_CERTIFICATE not set — skipping import; build.sh will ad-hoc sign (not distributable)."
+            exit 0
+          fi
+          KEYCHAIN="$RUNNER_TEMP/wso2-signing.keychain-db"
+          KC_PASS="${KEYCHAIN_PASSWORD:-ci-$RANDOM-$RANDOM-$RANDOM}"
+          security create-keychain -p "$KC_PASS" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KC_PASS" "$KEYCHAIN"
+          # Sanity-check the decoded secret before importing: a PKCS#12 is a DER SEQUENCE, so it
+          # must start with 0x30. This separates "secret was mangled/truncated in transit" from
+          # "password does not match" — `security import` reports both as MAC verification failed.
+          check_p12() {
+            local f="$1" label="$2"
+            local size; size=$(wc -c < "$f" | tr -d ' ')
+            echo "$label: decoded $size bytes"
+            if [ "$size" -lt 100 ]; then
+              echo "::error::$label decoded to only $size bytes — the secret is empty or truncated, not base64 of a .p12"
+              exit 1
+            fi
+            if [ "$(head -c1 "$f" | od -An -tx1 | tr -d ' \n')" != "30" ]; then
+              echo "::error::$label does not look like a PKCS#12/DER file — check the secret holds base64 of a .p12 (not a .cer, and no stray characters)"
+              exit 1
+            fi
+          }
+          echo "$MACOS_CERTIFICATE" | base64 --decode > "$RUNNER_TEMP/app_cert.p12"
+          check_p12 "$RUNNER_TEMP/app_cert.p12" "MACOS_CERTIFICATE"
+          if ! security import "$RUNNER_TEMP/app_cert.p12" -k "$KEYCHAIN" -P "$MACOS_CERTIFICATE_PASSWORD" -T /usr/bin/codesign; then
+            echo "::error::Importing MACOS_CERTIFICATE failed. The file decoded correctly, so MACOS_CERTIFICATE_PASSWORD does not match this .p12."
+            exit 1
+          fi
+          if [ -n "$MACOS_INSTALLER_CERTIFICATE" ]; then
+            echo "$MACOS_INSTALLER_CERTIFICATE" | base64 --decode > "$RUNNER_TEMP/installer_cert.p12"
+            check_p12 "$RUNNER_TEMP/installer_cert.p12" "MACOS_INSTALLER_CERTIFICATE"
+            if ! security import "$RUNNER_TEMP/installer_cert.p12" -k "$KEYCHAIN" -P "$MACOS_INSTALLER_CERTIFICATE_PASSWORD" -T /usr/bin/productbuild -T /usr/bin/productsign; then
+              echo "::error::Importing MACOS_INSTALLER_CERTIFICATE failed. The file decoded correctly, so MACOS_INSTALLER_CERTIFICATE_PASSWORD does not match this .p12."
+              exit 1
+            fi
+          fi
+          security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | tr -d '"')
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KC_PASS" "$KEYCHAIN" >/dev/null
+          rm -f "$RUNNER_TEMP/app_cert.p12" "$RUNNER_TEMP/installer_cert.p12"
+          APP_ID=$(security find-identity -v -p codesigning "$KEYCHAIN" | grep -o '"Developer ID Application: [^"]*"' | head -1 | tr -d '"')
+          INST_ID=$(security find-identity -v "$KEYCHAIN" | grep -o '"Developer ID Installer: [^"]*"' | head -1 | tr -d '"')
+          if [ -z "$APP_ID" ]; then
+            echo "No Developer ID Application identity found after import" >&2
+            exit 1
+          fi
+          echo "MAC_SIGNING_IDENTITY=$APP_ID" >> "$GITHUB_ENV"
+          if [ -n "$INST_ID" ]; then
+            echo "MAC_INSTALLER_SIGNING_IDENTITY=$INST_ID" >> "$GITHUB_ENV"
+          fi
+          echo "Imported certificates. App identity: $APP_ID | Installer identity: ${INST_ID:-none}"
+
+      # MAC_SIGNING_IDENTITY / MAC_INSTALLER_SIGNING_IDENTITY come from the import step
+      # via GITHUB_ENV (derived from the imported certificates).
+
       - name: Build macOS installer packages
         if: ${{ inputs.build_packed_installers == true }}
         run: |
@@ -578,6 +648,55 @@ jobs:
           wget -O jre.zip "$JRE_URL"
           ./build.sh ballerina.zip $BALLERINA_VERSION VSCode-darwin-${{ matrix.arch }}.zip icp.zip jre.zip $INTEGRATOR_VERSION ${{ matrix.arch }}
           cd ${ROOT_DIR}
+
+      # Apple-ID (app-specific password) notarytool auth. NOTARY_APP_PASSWORD is an
+      # app-specific password generated at appleid.apple.com, not the account password.
+      - name: Notarize and staple (macOS ${{ matrix.arch }})
+        if: ${{ inputs.build_packed_installers == true }}
+        # The job's default working-directory is lib/vscode, where installers/mac does not exist —
+        # without this override the loop below finds nothing, skips everything, and exits 0: a green
+        # step that notarized nothing.
+        working-directory: .
+        env:
+          NOTARY_APPLE_ID: ${{ secrets.NOTARY_APPLE_ID }}
+          NOTARY_APP_PASSWORD: ${{ secrets.NOTARY_APP_PASSWORD }}
+          NOTARY_TEAM_ID: ${{ secrets.NOTARY_TEAM_ID }}
+          # Bound through env, never expanded into the script: the version derives from
+          # component-versions.properties on whatever ref was dispatched, and this step holds
+          # notarization credentials.
+          INTEGRATOR_VERSION: ${{ needs.resolve-versions.outputs.integrator_version }}
+        run: |
+          set -euo pipefail
+          V="$INTEGRATOR_VERSION"
+          DMG="installers/mac/wso2-integrator-${V}-${{ matrix.arch }}.dmg"
+          PKG="installers/mac/wso2-integrator-${V}-${{ matrix.arch }}.pkg"
+          if [ -z "$NOTARY_APPLE_ID" ] || [ -z "$NOTARY_APP_PASSWORD" ] || [ -z "$NOTARY_TEAM_ID" ]; then
+            echo "Notarization credentials not set — skipping notarization (build is signed but not notarized)."
+            exit 0
+          fi
+          # Submitting ad-hoc or unsigned artifacts can only fail at Apple's end, so without both
+          # signing identities this build is the documented unsigned fallback — skip, don't submit.
+          if [ -z "${MAC_SIGNING_IDENTITY:-}" ] || [ -z "${MAC_INSTALLER_SIGNING_IDENTITY:-}" ]; then
+            echo "Signing identities not available — skipping notarization (unsigned fallback build)."
+            exit 0
+          fi
+          # A signed release ships BOTH artifacts; notarizing a partial set would look green while
+          # publishing an un-notarized installer.
+          for ARTIFACT in "$DMG" "$PKG"; do
+            if [ ! -f "$ARTIFACT" ]; then
+              echo "::error::expected artifact missing before notarization: $ARTIFACT" >&2
+              exit 1
+            fi
+          done
+          for ARTIFACT in "$DMG" "$PKG"; do
+            echo "Notarizing $ARTIFACT"
+            xcrun notarytool submit "$ARTIFACT" \
+              --apple-id "$NOTARY_APPLE_ID" \
+              --password "$NOTARY_APP_PASSWORD" \
+              --team-id "$NOTARY_TEAM_ID" \
+              --wait
+            xcrun stapler staple "$ARTIFACT"
+          done
 
       - name: Upload macOS DMG artifacts
         if: ${{ inputs.build_packed_installers == true }}

--- a/installers/mac/build.sh
+++ b/installers/mac/build.sh
@@ -151,16 +151,95 @@ mv "$ICP_UNZIPPED_PATH"/* "$ICP_TARGET"
 rm -rf "$ICP_UNZIPPED_PATH"
 chmod +x "$ICP_TARGET/bin"/*
 
-# Modify icp.sh to use the JRE from shared dependencies directory
+# Make icp.sh resolve the JVM env-aware (§D8): prefer the resolved JDK home advertised by the
+# product runtime environment (WSO2_INTEGRATOR_JRE_HOME — set once ICP/JRE are seeded to the data
+# folder), else fall back to the JRE bundled next to ICP (../../dependencies). Replace icp's bare
+# `java` calls with $WSO2_ICP_JAVA, then prepend a resolver that sets it (added AFTER the replace
+# so its own `bin/java` isn't itself rewritten). Backward-compatible: with the env var unset it
+# resolves to exactly the previous relative path.
 ICP_SCRIPT="$ICP_TARGET/bin/icp.sh"
 if [ -f "$ICP_SCRIPT" ]; then
-    print_info "Modifying icp.sh to use JRE from dependencies ($JRE_FOLDER)"
-    # Replace standalone 'java' invocations with the full path to the JRE java (word-boundary match)
-    sed -i '' -E "s|[[:<:]]java[[:>:]]|\"\$SCRIPT_DIR\"/../../dependencies/$JRE_FOLDER/bin/java|g" "$ICP_SCRIPT"
+    print_info "Modifying icp.sh to use JRE (env-aware, fallback $JRE_FOLDER)"
+    sed -i '' -E "s|[[:<:]]java[[:>:]]|\"\$WSO2_ICP_JAVA\"|g" "$ICP_SCRIPT"
+    ICP_TMP="$(mktemp)"
+    {
+        head -n 1 "$ICP_SCRIPT"
+        cat <<EOF
+WSO2_ICP_JAVA=""
+_wso2_icp_sd="\$(cd "\$(dirname "\$0")" && pwd)"
+if [ -n "\$WSO2_INTEGRATOR_JRE_HOME" ] && [ -x "\$WSO2_INTEGRATOR_JRE_HOME/bin/java" ]; then
+  WSO2_ICP_JAVA="\$WSO2_INTEGRATOR_JRE_HOME/bin/java"
+else
+  WSO2_ICP_JAVA="\$_wso2_icp_sd/../../dependencies/$JRE_FOLDER/bin/java"
+fi
+EOF
+        tail -n +2 "$ICP_SCRIPT"
+    } > "$ICP_TMP"
+    mv "$ICP_TMP" "$ICP_SCRIPT"
+    # 755 explicitly, not +x: the temp file was created 0600, and an icp.sh that group/other cannot
+    # READ cannot be executed by them either (the interpreter has to read it). Root-owned installs
+    # (deb/rpm) would otherwise ship an ICP that only root can launch.
+    chmod 755 "$ICP_SCRIPT"
 fi
 
 # Fix ZIP epoch timestamps — unzip preserves 1980-01-01 dates from ZIP archives
 find "$WSO2_TARGET/WSO2 Integrator.app" -exec touch {} +
+
+# -------------------------------------------------------------------
+# Code-sign a fully-assembled app bundle (Developer ID + hardened runtime), inside-out:
+# loose Mach-O + component executables, then nested bundles deepest-first, then the top
+# app. Falls back to ad-hoc signing when no identity is configured (local/dev builds) so
+# the app still launches. Reused for the full app and the stripped editor-only update
+# bundle (§D8) — stripping files breaks the seal, so the editor-only copy is re-signed.
+# -------------------------------------------------------------------
+ENTITLEMENTS="$WORK_DIR/entitlements.plist"
+sign_app_bundle() {
+    local app="$1"
+    if [ -n "${MAC_SIGNING_IDENTITY:-}" ]; then
+        print_info "Signing app with Developer ID identity: $MAC_SIGNING_IDENTITY ($app)"
+        # Executables and bundles get the entitlements (the union covers Electron + the bundled
+        # JVM, which needs jit/unsigned-exec-memory/dyld-env/library-validation exceptions);
+        # libraries get NONE -- entitlements on a dylib grant nothing and only widen what an
+        # auditor has to reason about.
+        local SIGN_OPTS=(--force --timestamp --options runtime --entitlements "$ENTITLEMENTS" --sign "$MAC_SIGNING_IDENTITY")
+        local LIB_OPTS=(--force --timestamp --options runtime --sign "$MAC_SIGNING_IDENTITY")
+
+        # 1) Loose Mach-O content: libraries and native node addons first (no entitlements), then
+        #    executables inside the bundled components (Ballerina/JVM/ICP), then the repackaged CLI
+        #    under Resources/app/bin -- a bare Mach-O there is covered by no other pass, and one
+        #    unsigned executable fails notarization for the whole app.
+        find "$app" -type f \( -name "*.dylib" -o -name "*.so" -o -name "*.node" -o -name "*.jnilib" \) -print0 \
+            | while IFS= read -r -d '' f; do codesign "${LIB_OPTS[@]}" "$f"; done
+        if [ -d "$app/Contents/components" ]; then
+            find "$app/Contents/components" -type f -perm +111 ! -name "*.jar" -print0 \
+                | while IFS= read -r -d '' f; do codesign "${SIGN_OPTS[@]}" "$f"; done
+        fi
+        if [ -d "$app/Contents/Resources/app/bin" ]; then
+            find "$app/Contents/Resources/app/bin" -type f -perm +111 -print0 \
+                | while IFS= read -r -d '' f; do
+                    if file "$f" | grep -q "Mach-O"; then codesign "${SIGN_OPTS[@]}" "$f"; fi
+                  done
+        fi
+
+        # 2) Nested bundles (Electron frameworks + helper .apps), deepest path first.
+        find "$app" -type d \( -name "*.framework" -o -name "*.app" \) | awk '{ print length, $0 }' | sort -rn | cut -d' ' -f2- \
+            | while IFS= read -r bundle; do
+                [ "$bundle" = "$app" ] && continue
+                codesign "${SIGN_OPTS[@]}" "$bundle"
+              done
+
+        # 3) The top-level app last, then verify the seal.
+        codesign "${SIGN_OPTS[@]}" "$app"
+        codesign --verify --deep --strict --verbose=2 "$app"
+        print_info "App signed and verified: $app"
+    else
+        print_warning "MAC_SIGNING_IDENTITY not set — ad-hoc signing (not distributable or notarizable)"
+        codesign --force --deep --sign - "$app"
+    fi
+}
+
+SIGN_APP="$WSO2_TARGET/WSO2 Integrator.app"
+sign_app_bundle "$SIGN_APP"
 
 # Build the component package
 pkgbuild --root "$EXTRACTION_TARGET" \
@@ -174,11 +253,24 @@ pkgbuild --root "$EXTRACTION_TARGET" \
 sed -i '' "s/version=\"__VERSION__\"/version=\"$VERSION\"/g" "$WORK_DIR/Distribution.xml"
 
 
-# Build the final product archive
-productbuild --distribution "$WORK_DIR/Distribution.xml" \
-             --resources "$WORK_DIR" \
-             --package-path "$WORK_DIR" \
-             "wso2-integrator-$VERSION-$ARCH.pkg"
+# Build the final product archive. Signed with the Developer ID Installer identity
+# when available — an unsigned .pkg cannot be notarized. (App bundles inside are
+# already codesigned with the Application identity; the pkg wrapper needs its own.)
+if [ -n "${MAC_INSTALLER_SIGNING_IDENTITY:-}" ]; then
+    print_info "Signing installer package with: $MAC_INSTALLER_SIGNING_IDENTITY"
+    productbuild --distribution "$WORK_DIR/Distribution.xml" \
+                 --resources "$WORK_DIR" \
+                 --package-path "$WORK_DIR" \
+                 --sign "$MAC_INSTALLER_SIGNING_IDENTITY" \
+                 --timestamp \
+                 "wso2-integrator-$VERSION-$ARCH.pkg"
+else
+    print_warning "MAC_INSTALLER_SIGNING_IDENTITY not set — .pkg will be unsigned (not notarizable)"
+    productbuild --distribution "$WORK_DIR/Distribution.xml" \
+                 --resources "$WORK_DIR" \
+                 --package-path "$WORK_DIR" \
+                 "wso2-integrator-$VERSION-$ARCH.pkg"
+fi
 
 sed -i '' "s/version=\"$VERSION\"/version=\"__VERSION__\"/g" "$WORK_DIR/Distribution.xml"
 
@@ -287,15 +379,35 @@ APPLESCRIPT
 print_info "Finalising DMG"
 sync
 sleep 3
+# Something transiently holds a freshly-written volume — Spotlight indexing, fsevents, or the
+# Finder used for the window layout above. Three attempts two seconds apart was not enough on a
+# real arm64 runner: the build failed here after the app had been signed and the pkg written.
+#
+# So: escalate the backoff to ~30s total, name the holder when it fails (otherwise the next
+# occurrence is just as mysterious as this one was), and fall back to diskutil, which can evict a
+# volume hdiutil will not.
 _detach_ok=0
-for _retry in 1 2 3; do
+for _retry in 1 2 3 4 5 6; do
     if hdiutil detach "$DMG_MOUNT_DIR" -force -quiet; then
         _detach_ok=1; break
     fi
-    [ "$_retry" -lt 3 ] && { print_info "Detach attempt $_retry failed, retrying in 2s..."; sleep 2; }
+    if [ "$_retry" -lt 6 ]; then
+        _wait=$((_retry * 2))
+        print_info "Detach attempt $_retry failed; who is holding it:"
+        lsof +D "$DMG_MOUNT_DIR" 2>/dev/null | head -8 || true
+        print_info "Retrying in ${_wait}s..."
+        sleep "$_wait"
+    fi
 done
 if [ "$_detach_ok" -eq 0 ]; then
-    print_error "Could not unmount $DMG_MOUNT_DIR after 3 attempts; aborting before DMG conversion"
+    print_info "hdiutil could not detach; trying diskutil unmount force"
+    if diskutil unmount force "$DMG_MOUNT_DIR" >/dev/null 2>&1; then
+        _detach_ok=1
+    fi
+fi
+if [ "$_detach_ok" -eq 0 ]; then
+    print_error "Could not unmount $DMG_MOUNT_DIR; aborting before DMG conversion"
+    lsof +D "$DMG_MOUNT_DIR" 2>/dev/null | head -20 || true
     exit 1
 fi
 DMG_MOUNT_DIR=""  # Clear only after successful detach so the trap can still retry on failure
@@ -311,6 +423,14 @@ else
     print_error "Failed to create DMG package"
     exit 1
 fi
+
+# Sign the DMG container itself with the Application identity (the app inside is
+# already signed); recommended for notarization and a cleaner Gatekeeper experience.
+if [ -n "${MAC_SIGNING_IDENTITY:-}" ]; then
+    print_info "Signing DMG with: $MAC_SIGNING_IDENTITY"
+    codesign --force --timestamp --sign "$MAC_SIGNING_IDENTITY" "$WORK_DIR/$DMG_NAME"
+fi
+
 
 # Temp files cleaned by the EXIT trap
 trap - EXIT

--- a/installers/mac/entitlements.plist
+++ b/installers/mac/entitlements.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<!-- One entitlements file signs everything in the bundle: the Electron app AND the deep-signed
+     runtime components (the JVM, Ballerina's native tools). The set below is the union both need;
+     it deliberately matches what notarized JDK distributions ship, since the JVM is the most
+     demanding signee. Sandbox-only keys (network.*, files.*) are omitted — without
+     com.apple.security.app-sandbox they are ignored, and listing them only misleads. -->
+<dict>
+	<!-- Electron / V8 and the JVM's JIT need writable+executable memory. -->
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+	<!-- The JVM loads JNI libraries that are not signed by us, and both it and Electron
+	     read DYLD_* environment variables. -->
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+	<key>com.apple.security.cs.allow-dyld-environment-variables</key>
+	<true/>
+	<!-- Opening URLs / revealing files through other apps. -->
+	<key>com.apple.security.automation.apple-events</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
Backport of #2247 to `staging/5.1.0`.

Cherry-picked from `1750493` with no conflicts. The diff is identical to the commit on `main`.

## Why this is on the release line

The scheduled Daily Build compiles `staging/5.1.0` but reads its workflow files from `main`
(`uses: ./.github/workflows/build.yml` resolves from the caller's ref, which for a scheduled run is
the default branch). `main`'s `build.yml` has expected the macOS signing and notarization steps
since Sep 4. This puts the matching `installers/mac/build.sh` and entitlements on the branch that
is actually built.

## What it contains

- Imports the Developer ID Application and Developer ID Installer certificates into a temporary
  keychain, deriving the identity names from the imported certificates.
- Signs hardened-runtime with entitlements, deepest-first: loose Mach-O and bundled component
  executables, then nested bundles, then the top-level app, then the DMG container.
- Notarizes and staples the DMG and PKG with `notarytool`, failing when the artifacts are missing.

Every signing step is skipped when the secrets are absent, so a run without them produces an
ad-hoc-signed app rather than failing.

## Part 1 of 2

#2248 is stacked on this branch and must merge after it. Squirrel.Mac requires a validly signed app.

## Verification

- Cherry-pick applied with 0 conflicts.
- `installers/` on this branch is byte-identical to `upstream/main`.
- `.github/workflows/build.yml` parses.
- Not run in CI on this branch yet.