### PR TITLE
[CI] Align the nightly workflow with the ballerina-vscode workflow layering

### DIFF
--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -1,4 +1,4 @@
-name: Daily Build
+name: Nightly Build
 
 # The nightly, and nothing else. Once a day it:
 #
@@ -234,7 +234,8 @@ jobs:
   build:
     name: Build
     needs: prepare-nightly
-    uses: ./.github/workflows/build.yml
+    # Via dev-build.yml so both routes reach build.yml through one place.
+    uses: ./.github/workflows/dev-build.yml
     secrets: inherit
     with:
       # Build the commit just pushed to the configured pinned-build branch, not the mutable source
@@ -246,7 +247,6 @@ jobs:
       versions_artifact: versions
       # build.yml replaces only the configured rolling release/tag, whichever that is.
       publish_tag: ${{ needs.prepare-nightly.outputs.publish_tag }}
-      is_prerelease: true
       runner: ${{ inputs.runner || 'ubuntu-latest' }}
       build_linux: true
       build_macos: true

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -6,7 +6,8 @@ name: Development Build
 # with the extension at 1.1.<yymmddHH>. Nothing is committed to any branch and nothing is published
 # to GitHub Releases; you get the workflow artifacts.
 #
-# The nightly is daily-build.yml; real releases are release.yml.
+# daily-build.yml calls this for the nightly, passing the `workflow_call` inputs below. Real
+# releases are release.yml.
 
 on:
   workflow_dispatch:
@@ -60,6 +61,67 @@ on:
         options:
           - marketplace
           - github
+  # Absent from workflow_dispatch on purpose: a dispatch must not be able to pin a foreign tree or
+  # replace a release, so on that route these are empty.
+  workflow_call:
+    inputs:
+      ref:
+        description: 'Ref or SHA to build. Empty builds the ref this workflow was called from.'
+        required: false
+        default: ''
+        type: string
+      target_commitish:
+        description: 'Commit the published tag should point at.'
+        required: false
+        default: ''
+        type: string
+      versions_artifact:
+        description: 'Artifact holding the already-stamped versions. Empty stamps here.'
+        required: false
+        default: ''
+        type: string
+      publish_tag:
+        description: 'Rolling tag and release to replace. Empty publishes nothing.'
+        required: false
+        default: ''
+        type: string
+      runner:
+        required: false
+        default: 'ubuntu-latest'
+        type: string
+      build_linux:
+        required: false
+        default: true
+        type: boolean
+      build_macos:
+        required: false
+        default: true
+        type: boolean
+      build_windows:
+        required: false
+        default: true
+        type: boolean
+      build_packed_installers:
+        required: false
+        default: true
+        type: boolean
+      run_smoke_tests:
+        required: false
+        default: true
+        type: boolean
+      smoke_tests_required:
+        description: 'Fail the build when the smoke tests fail.'
+        required: false
+        default: false
+        type: boolean
+      ballerina_extension_source:
+        required: false
+        default: 'github'
+        type: string
+      mi_extension_source:
+        required: false
+        default: 'github'
+        type: string
 
 # `contents: write` is required even though this dispatcher itself commits nothing: GitHub
 # statically checks that a caller's permissions are at least what a reusable workflow it calls
@@ -80,9 +142,11 @@ jobs:
     uses: ./.github/workflows/build.yml
     secrets: inherit
     with:
-      # No artifact, so build.yml stamps the dispatched ref itself; no tag, so nothing is published.
-      versions_artifact: ''
-      publish_tag: ''
+      # Empty on the dispatch route: stamp the dispatched ref, publish nothing.
+      ref: ${{ inputs.ref || '' }}
+      target_commitish: ${{ inputs.target_commitish || '' }}
+      versions_artifact: ${{ inputs.versions_artifact || '' }}
+      publish_tag: ${{ inputs.publish_tag || '' }}
       is_prerelease: true
       runner: ${{ inputs.runner }}
       build_linux: ${{ inputs.build_linux }}
@@ -90,5 +154,6 @@ jobs:
       build_windows: ${{ inputs.build_windows }}
       build_packed_installers: ${{ inputs.build_packed_installers }}
       run_smoke_tests: ${{ inputs.run_smoke_tests }}
+      smoke_tests_required: ${{ inputs.smoke_tests_required || false }}
       ballerina_extension_source: ${{ inputs.ballerina_extension_source }}
       mi_extension_source: ${{ inputs.mi_extension_source }}

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -45,6 +45,11 @@ on:
         required: true
         default: true
         type: boolean
+      smoke_tests_required:
+        description: 'Whether a failing smoke test fails this build.'
+        required: false
+        default: true
+        type: boolean
       ballerina_extension_source:
         description: 'Choose whether to bundle Ballerina from GitHub VSIX or use marketplace flow'
         required: true
@@ -112,7 +117,7 @@ on:
       smoke_tests_required:
         description: 'Fail the build when the smoke tests fail.'
         required: false
-        default: false
+        default: true
         type: boolean
       ballerina_extension_source:
         required: false
@@ -154,6 +159,6 @@ jobs:
       build_windows: ${{ inputs.build_windows }}
       build_packed_installers: ${{ inputs.build_packed_installers }}
       run_smoke_tests: ${{ inputs.run_smoke_tests }}
-      smoke_tests_required: ${{ inputs.smoke_tests_required || false }}
+      smoke_tests_required: ${{ inputs.smoke_tests_required }}
       ballerina_extension_source: ${{ inputs.ballerina_extension_source }}
       mi_extension_source: ${{ inputs.mi_extension_source }}


### PR DESCRIPTION
Aligns the nightly with the workflow layering and naming used in `ballerina-vscode`. 

## The convention

`ballerina-vscode` layers its nightly as:

```
schedule.yml  ("Nightly Build")  →  devBuild.yml  ("Development Build")  →  reusable-build.yml
```

`devBuild.yml` is a thin wrapper with one job; `schedule.yml` reuses it after stamping the nightly
branch rather than calling the build pipeline itself.

This repo maps onto that one-for-one — `daily-build.yml`, `dev-build.yml`, `build.yml`,
`release.yml` — but diverged in two places: the middle layer was bypassed, and the entry point was
named differently.

## 1. Route the nightly through `dev-build.yml`

```
before:  daily-build.yml → build.yml          (dev-build.yml alongside, a second caller)
after:   daily-build.yml → dev-build.yml → build.yml
```

- `dev-build.yml` gains a `workflow_call` block and forwards `ref`, `target_commitish`,
  `versions_artifact` and `publish_tag` through to `build.yml`.
- `daily-build.yml`'s `build` job calls `dev-build.yml`. What it passes is otherwise unchanged.

Two files previously duplicated the same input list, so adding an input to `build.yml` meant
remembering both.

**The dispatch route is deliberately unable to publish.** `ref`, `target_commitish`,
`versions_artifact` and `publish_tag` are `workflow_call`-only and absent from `workflow_dispatch`,
so a manual dev build cannot pin a foreign tree or replace a release. They evaluate empty on that
route, which is exactly what `dev-build.yml` hardcoded before, and each is guarded with `|| ''`
rather than relying on an undefined input evaluating to an empty string.

`is_prerelease` is no longer passed by `daily-build.yml`: `dev-build.yml` hardcodes it `true`, which
is what the nightly wants. Only `release.yml`, which calls `build.yml` directly, publishes a GA
release.

## 2. Name it "Nightly Build"

`name: Daily Build` → `name: Nightly Build`, matching `schedule.yml` in `ballerina-vscode`.

It also ends a split inside this repo, where the workflow was the only thing calling itself daily:
the branch is `builds/nightly`, the tag is `nightly`, the job is `prepare-nightly`, the script is
`resolve-nightly-versions.sh`, and the file's own header opens "The nightly, and nothing else."

The **filename stays `daily-build.yml`**. Renaming it would register a new workflow with GitHub and
split the nightly's run history across two entries in the Actions UI, which is a poor trade for a
workflow whose history is what you read when a build breaks.

> **Before merging:** if branch protection or any notification rule references a required check
> named "Daily Build", that link breaks and needs updating in the repository settings. I cannot see
> those settings from here.

## What this does not change

A scheduled run still reads its workflow files from the default branch while `ref` selects a
`staging/*` tree, because `uses:` resolves the called workflow from the caller's ref and cannot take
an expression. That is the condition behind the Windows failures, and it is unchanged here by
design — it is managed by keeping `staging/*` in sync with `main`'s build infrastructure, as #2384
and #2385 did.

For the record, `ballerina-vscode` has the same exposure: its `resolve-source-branch` also resets
`builds/nightly` to the latest `staging/*` branch when one exists, so its nightly builds a staging
tree with `main`'s pipeline too. A VSIX build touches far fewer tree-side scripts than five
installer builds, so it has not surfaced there.

## Verification

- All three workflow files parse.
- Every input `daily-build.yml` passes is accepted by `dev-build.yml`'s `workflow_call` block, and
  every input `dev-build.yml` forwards is accepted by `build.yml`. Checked by diffing the key sets,
  which is how the `is_prerelease` mismatch above was found.
- `dev-build.yml`'s dispatch inputs are untouched, so the manual "build my branch" UI is unchanged.
- "Daily Build" appeared only on line 1 and no longer appears anywhere in `.github`, `ci` or `docs`.

**Not verified:** no run has exercised either route. The two worth running before merge are a
`dev-build.yml` dispatch, which must still build the dispatched ref and publish nothing, and a
`daily-build.yml` dispatch with `build_branch=builds/nightly-test` and `publish_tag=nightly-test`,
which exercises the nightly route without touching production.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renamed the automated “Daily Build” process to “Nightly Build.”
  * Updated build automation to support configurable references, release publication, platform builds, version artifacts, extension sources, and smoke-test settings.
  * Added support for invoking development builds through reusable automation while preserving manual-dispatch behavior for the current code revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->