### PR TITLE
[staging/5.1.0] Derive the signing public key and harden the update-publish preflight

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1600,7 +1600,7 @@ jobs:
     env:
       # secrets can't be referenced from a step `if:`, so their presence is hoisted here — the same
       # reason HAS_AWS exists on the build jobs.
-      HAS_PINNED_KEY: ${{ secrets.WSO2_UPDATE_PUBLIC_KEY != '' && secrets.COSIGN_PUBLIC_KEY != '' }}
+      HAS_PINNED_KEY: ${{ secrets.WSO2_UPDATE_PUBLIC_KEY != '' }}
       # New builds publish to the channel chosen at dispatch (default insider); the
       # promote-channel workflow later copies a source document down the ladder.
       CHANNEL: ${{ inputs.channel || 'insider' }}
@@ -1691,33 +1691,47 @@ jobs:
         if: ${{ steps.targets.outputs.targets != '' }}
         uses: sigstore/cosign-installer@v3
 
+      # The public half is DERIVED from the signing key rather than configured separately. A second
+      # public-key secret can only agree or disagree with this one, and when it disagreed the
+      # signatures still verified in-run -- so the mismatch that matters (pinned key vs the key that
+      # actually signs) was the one the old check could not see.
+      - name: Derive the signing public key
+        if: ${{ steps.targets.outputs.targets != '' }}
+        run: |
+          set -euo pipefail
+          cosign public-key --key env://COSIGN_PRIVATE_KEY > signing.pub
+          grep -q 'BEGIN PUBLIC KEY' signing.pub
+          echo "derived the public half of COSIGN_PRIVATE_KEY"
+        env:
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+
       # The client verifies artifacts against WSO2_UPDATE_PUBLIC_KEY, baked into product.json at
       # build time; CI signs with COSIGN_PRIVATE_KEY. Nothing downstream compares the two, so if they
       # are not the same key pair every client rejects every artifact — and the signing steps below
-      # still pass, because they verify against COSIGN_PUBLIC_KEY. That failure would only surface on
+      # still pass, because they verify against the signing key itself. That failure would only surface on
       # a user's machine, after the release. One base64 decode catches it here instead.
       - name: Check the pinned key matches the signing key
         if: ${{ steps.targets.outputs.targets != '' && env.HAS_PINNED_KEY == 'true' }}
         run: |
           set -euo pipefail
           printf '%s' "$WSO2_UPDATE_PUBLIC_KEY" | base64 -d > pinned.pem 2>/dev/null || {
-            echo "::error::WSO2_UPDATE_PUBLIC_KEY is not valid base64. It must be 'base64 < cosign.pub'." >&2
+            echo "::error::WSO2_UPDATE_PUBLIC_KEY is not valid base64. It must be 'base64 -w0 < cosign.pub'." >&2
             exit 1
           }
-          printf '%s' "$COSIGN_PUBLIC_KEY" > signing.pem
-          # Compare the DER of each, so PEM line wrapping or a trailing newline cannot fail a
-          # correctly configured pair.
+          # Compared against the key derived from COSIGN_PRIVATE_KEY, so this proves the pinned key
+          # matches the key that actually signs. DER, so PEM wrapping or a trailing newline cannot
+          # fail a correctly configured pair.
           openssl pkey -pubin -in pinned.pem  -outform DER -out pinned.der
-          openssl pkey -pubin -in signing.pem -outform DER -out signing.der
+          openssl pkey -pubin -in signing.pub -outform DER -out signing.der
           if ! cmp -s pinned.der signing.der; then
-            echo "::error::WSO2_UPDATE_PUBLIC_KEY does not match COSIGN_PUBLIC_KEY. Clients built here would reject every artifact this run signs." >&2
+            echo "::error::WSO2_UPDATE_PUBLIC_KEY is not the public half of COSIGN_PRIVATE_KEY. Clients built here would reject every artifact this run signs." >&2
             exit 1
           fi
           echo "Pinned client key matches the signing key."
-          rm -f pinned.pem signing.pem pinned.der signing.der
+          rm -f pinned.pem pinned.der signing.der
         env:
           WSO2_UPDATE_PUBLIC_KEY: ${{ secrets.WSO2_UPDATE_PUBLIC_KEY }}
-          COSIGN_PUBLIC_KEY: ${{ secrets.COSIGN_PUBLIC_KEY }}
 
       - name: Sign source document
         if: ${{ steps.targets.outputs.targets != '' }}
@@ -1729,11 +1743,7 @@ jobs:
       - name: Verify source signature
         if: ${{ steps.targets.outputs.targets != '' }}
         run: |
-          printf '%s' "$COSIGN_PUBLIC_KEY" > cosign.pub
-          cosign verify-blob --key cosign.pub --signature source.json.sig source.json
-          rm -f cosign.pub
-        env:
-          COSIGN_PUBLIC_KEY: ${{ secrets.COSIGN_PUBLIC_KEY }}
+          cosign verify-blob --key signing.pub --signature source.json.sig source.json
 
       - name: Upload source artifact
         if: ${{ steps.targets.outputs.targets != '' }}
@@ -1764,7 +1774,7 @@ jobs:
           fi
           # Public key as a file, matching the source verify step: cosign's env:// keyref is used
           # for the private key, and the proven pattern here for verification is a key file.
-          printf '%s' "$COSIGN_PUBLIC_KEY" > cosign.pub
+
           # Sign the STATEMENTS the generator wrote, not the artifacts themselves. A signature over
           # artifact bytes proves only "WSO2 produced this file", which would leave the document free
           # to offer an old signed artifact under a new version label; the statement binds
@@ -1774,10 +1784,9 @@ jobs:
             cosign sign-blob --key env://COSIGN_PRIVATE_KEY "${file}" --output-signature "${file}.sig" --yes
             # Verify immediately: a signature that cannot be checked here would ship as one the
             # client rejects, turning a signing misconfiguration into a failed update for users.
-            cosign verify-blob --key cosign.pub --signature "${file}.sig" "${file}"
+            cosign verify-blob --key signing.pub --signature "${file}.sig" "${file}"
             echo "signed $(basename "${file}")"
           done
-          rm -f cosign.pub
           # Every mirrored artifact must have one: an unsigned artifact would be served with a
           # statement URL that 404s, which the client treats as a hard failure.
           artifacts=$(find artifacts-mirror -type f ! -name '*.statement.json' ! -name '*.sig' | wc -l | tr -d ' ')
@@ -1790,7 +1799,6 @@ jobs:
         env:
           COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
-          COSIGN_PUBLIC_KEY: ${{ secrets.COSIGN_PUBLIC_KEY }}
 
       - name: Upload mirrored artifacts to update bucket
         if: ${{ steps.targets.outputs.targets != '' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -211,6 +211,46 @@ jobs:
           WSO2_UPDATE_PUBLIC_KEY: ${{ secrets.WSO2_UPDATE_PUBLIC_KEY }}
           COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
 
+      - name: cosign-installer
+        if: ${{ inputs.publish_update_source == true && inputs.build_packed_installers == true && inputs.publish_tag != '' }}
+        uses: sigstore/cosign-installer@v3
+
+      # Presence is not enough: a pinned key from the wrong pair passes every check downstream,
+      # because the signing steps verify against the signing key itself. Only comparing the two
+      # catches it, and it has to happen here — build-macos and build-windows bake the pinned key
+      # into product.json, so a comparison in Publish Update Source runs after the installers that
+      # carry the wrong key already exist. Deriving here also exercises COSIGN_PASSWORD, which
+      # would otherwise fail a full build later.
+      - name: Verify the pinned client key matches the signing key
+        if: ${{ inputs.publish_update_source == true && inputs.build_packed_installers == true && inputs.publish_tag != '' }}
+        run: |
+          set -euo pipefail
+          cosign public-key --key env://COSIGN_PRIVATE_KEY > signing.pub
+          grep -q 'BEGIN PUBLIC KEY' signing.pub
+          printf '%s' "$WSO2_UPDATE_PUBLIC_KEY" | base64 -d > pinned.pem 2>/dev/null || {
+            echo "::error::WSO2_UPDATE_PUBLIC_KEY is not valid base64. It must be 'base64 -w0 < cosign.pub'." >&2
+            exit 1
+          }
+          # base64 -d accepts the empty string, so an empty secret would otherwise reach openssl
+          # and die there with an opaque parse error instead of this one.
+          [ -s pinned.pem ] || {
+            echo "::error::WSO2_UPDATE_PUBLIC_KEY decoded to nothing." >&2
+            exit 1
+          }
+          # DER, so PEM wrapping or a trailing newline cannot fail a correctly configured pair.
+          openssl pkey -pubin -in pinned.pem  -outform DER -out pinned.der
+          openssl pkey -pubin -in signing.pub -outform DER -out signing.der
+          if ! cmp -s pinned.der signing.der; then
+            echo "::error::WSO2_UPDATE_PUBLIC_KEY is not the public half of COSIGN_PRIVATE_KEY. Clients built here would reject every artifact this run signs." >&2
+            exit 1
+          fi
+          echo "pinned client key matches the signing key"
+          rm -f signing.pub pinned.pem pinned.der signing.der
+        env:
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+          WSO2_UPDATE_PUBLIC_KEY: ${{ secrets.WSO2_UPDATE_PUBLIC_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -1731,33 +1771,6 @@ jobs:
           COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
 
-      # The client verifies artifacts against WSO2_UPDATE_PUBLIC_KEY, baked into product.json at
-      # build time; CI signs with COSIGN_PRIVATE_KEY. Nothing downstream compares the two, so if they
-      # are not the same key pair every client rejects every artifact — and the signing steps below
-      # still pass, because they verify against the signing key itself. That failure would only surface on
-      # a user's machine, after the release. One base64 decode catches it here instead.
-      - name: Check the pinned key matches the signing key
-        if: ${{ steps.targets.outputs.targets != '' }}
-        run: |
-          set -euo pipefail
-          printf '%s' "$WSO2_UPDATE_PUBLIC_KEY" | base64 -d > pinned.pem 2>/dev/null || {
-            echo "::error::WSO2_UPDATE_PUBLIC_KEY is not valid base64. It must be 'base64 -w0 < cosign.pub'." >&2
-            exit 1
-          }
-          # Compared against the key derived from COSIGN_PRIVATE_KEY, so this proves the pinned key
-          # matches the key that actually signs. DER, so PEM wrapping or a trailing newline cannot
-          # fail a correctly configured pair.
-          openssl pkey -pubin -in pinned.pem  -outform DER -out pinned.der
-          openssl pkey -pubin -in signing.pub -outform DER -out signing.der
-          if ! cmp -s pinned.der signing.der; then
-            echo "::error::WSO2_UPDATE_PUBLIC_KEY is not the public half of COSIGN_PRIVATE_KEY. Clients built here would reject every artifact this run signs." >&2
-            exit 1
-          fi
-          echo "Pinned client key matches the signing key."
-          rm -f pinned.pem pinned.der signing.der
-        env:
-          WSO2_UPDATE_PUBLIC_KEY: ${{ secrets.WSO2_UPDATE_PUBLIC_KEY }}
-
       - name: Sign source document
         if: ${{ steps.targets.outputs.targets != '' }}
         run: cosign sign-blob --key env://COSIGN_PRIVATE_KEY source.json --output-signature source.json.sig --yes
@@ -1797,9 +1810,6 @@ jobs:
             echo "No mirrored artifacts to sign."
             exit 0
           fi
-          # Public key as a file, matching the source verify step: cosign's env:// keyref is used
-          # for the private key, and the proven pattern here for verification is a key file.
-
           # Sign the STATEMENTS the generator wrote, not the artifacts themselves. A signature over
           # artifact bytes proves only "WSO2 produced this file", which would leave the document free
           # to offer an old signed artifact under a new version label; the statement binds

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,6 +183,32 @@ jobs:
       integrator_version: ${{ steps.read-versions.outputs.integrator_version }}
       ballerina_jre_version: ${{ steps.read-versions.outputs.ballerina_jre_version }}
     steps:
+      # Checked here rather than in Publish Update Source, because build-macos and build-windows
+      # bake WSO2_UPDATE_URL and WSO2_UPDATE_PUBLIC_KEY into product.json long before that job
+      # runs. A late check cannot stop a run from shipping installers that pin no key and skip
+      # signature verification; this one can, and it costs seconds instead of a full build.
+      - name: Check the publish path is configured
+        if: ${{ inputs.publish_update_source == true }}
+        run: |
+          set -euo pipefail
+          missing=()
+          [ -n "${AWS_UPDATE_S3_BUCKET}" ] || missing+=("AWS_UPDATE_S3_BUCKET")
+          [ -n "${WSO2_UPDATE_ARTIFACTS_URL}" ] || missing+=("WSO2_UPDATE_ARTIFACTS_URL (artifacts must be mirrored; clients refuse upstream hosts)")
+          [ -n "${WSO2_UPDATE_URL}" ] || missing+=("WSO2_UPDATE_URL (clients built here would have no update endpoint)")
+          [ -n "${WSO2_UPDATE_PUBLIC_KEY}" ] || missing+=("WSO2_UPDATE_PUBLIC_KEY (clients built here would pin no key and accept unverified artifacts)")
+          [ -n "${COSIGN_PRIVATE_KEY}" ] || missing+=("COSIGN_PRIVATE_KEY")
+          if [ ${#missing[@]} -gt 0 ]; then
+            printf '::error::missing required secret: %s\n' "${missing[@]}" >&2
+            exit 1
+          fi
+          echo "publish path configured for channel ${{ inputs.channel || 'insider' }}"
+        env:
+          AWS_UPDATE_S3_BUCKET: ${{ secrets.AWS_UPDATE_S3_BUCKET }}
+          WSO2_UPDATE_ARTIFACTS_URL: ${{ secrets.WSO2_UPDATE_ARTIFACTS_URL }}
+          WSO2_UPDATE_URL: ${{ secrets.WSO2_UPDATE_URL }}
+          WSO2_UPDATE_PUBLIC_KEY: ${{ secrets.WSO2_UPDATE_PUBLIC_KEY }}
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -1598,9 +1624,6 @@ jobs:
       id-token: write
       contents: read
     env:
-      # secrets can't be referenced from a step `if:`, so their presence is hoisted here — the same
-      # reason HAS_AWS exists on the build jobs.
-      HAS_PINNED_KEY: ${{ secrets.WSO2_UPDATE_PUBLIC_KEY != '' }}
       # New builds publish to the channel chosen at dispatch (default insider); the
       # promote-channel workflow later copies a source document down the ladder.
       CHANNEL: ${{ inputs.channel || 'insider' }}
@@ -1712,7 +1735,7 @@ jobs:
       # still pass, because they verify against the signing key itself. That failure would only surface on
       # a user's machine, after the release. One base64 decode catches it here instead.
       - name: Check the pinned key matches the signing key
-        if: ${{ steps.targets.outputs.targets != '' && env.HAS_PINNED_KEY == 'true' }}
+        if: ${{ steps.targets.outputs.targets != '' }}
         run: |
           set -euo pipefail
           printf '%s' "$WSO2_UPDATE_PUBLIC_KEY" | base64 -d > pinned.pem 2>/dev/null || {

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -187,8 +187,10 @@ jobs:
       # bake WSO2_UPDATE_URL and WSO2_UPDATE_PUBLIC_KEY into product.json long before that job
       # runs. A late check cannot stop a run from shipping installers that pin no key and skip
       # signature verification; this one can, and it costs seconds instead of a full build.
+      # Conditions mirror the Publish Update Source job's own `if:`, so a run that would not
+      # publish anyway is never failed for missing publish secrets.
       - name: Check the publish path is configured
-        if: ${{ inputs.publish_update_source == true }}
+        if: ${{ inputs.publish_update_source == true && inputs.build_packed_installers == true && inputs.publish_tag != '' }}
         run: |
           set -euo pipefail
           missing=()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -195,6 +195,8 @@ jobs:
           set -euo pipefail
           missing=()
           [ -n "${AWS_UPDATE_S3_BUCKET}" ] || missing+=("AWS_UPDATE_S3_BUCKET")
+          [ -n "${AWS_ACCESS_KEY_ID}" ] || missing+=("AWS_ACCESS_KEY_ID (nothing could be uploaded to the update bucket)")
+          [ -n "${AWS_SECRET_ACCESS_KEY}" ] || missing+=("AWS_SECRET_ACCESS_KEY")
           [ -n "${WSO2_UPDATE_ARTIFACTS_URL}" ] || missing+=("WSO2_UPDATE_ARTIFACTS_URL (artifacts must be mirrored; clients refuse upstream hosts)")
           [ -n "${WSO2_UPDATE_URL}" ] || missing+=("WSO2_UPDATE_URL (clients built here would have no update endpoint)")
           [ -n "${WSO2_UPDATE_PUBLIC_KEY}" ] || missing+=("WSO2_UPDATE_PUBLIC_KEY (clients built here would pin no key and accept unverified artifacts)")
@@ -206,6 +208,8 @@ jobs:
           echo "publish path configured for channel ${{ inputs.channel || 'insider' }}"
         env:
           AWS_UPDATE_S3_BUCKET: ${{ secrets.AWS_UPDATE_S3_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           WSO2_UPDATE_ARTIFACTS_URL: ${{ secrets.WSO2_UPDATE_ARTIFACTS_URL }}
           WSO2_UPDATE_URL: ${{ secrets.WSO2_UPDATE_URL }}
           WSO2_UPDATE_PUBLIC_KEY: ${{ secrets.WSO2_UPDATE_PUBLIC_KEY }}

--- a/.github/workflows/publish-components.yml
+++ b/.github/workflows/publish-components.yml
@@ -71,11 +71,10 @@ jobs:
       CHANNEL: ${{ inputs.channel }}
       BUCKET: ${{ secrets.AWS_UPDATE_S3_BUCKET }}
       ARTIFACTS_URL: ${{ secrets.WSO2_UPDATE_ARTIFACTS_URL }}
-      # A step `if:` cannot see `secrets`, so presence is hoisted to job env.
-      HAS_PINNED_KEY: ${{ secrets.WSO2_UPDATE_PUBLIC_KEY != '' }}
     steps:
-      # Checked before the build rather than after it. All three are required: without mirroring or
-      # signing, the resulting document is one every client rejects.
+      # Checked before the build rather than after it. All four are required: without mirroring or
+      # signing, the resulting document is one every client rejects, and without the pinned key
+      # nothing proves the signature matches what released clients actually verify against.
       - name: Check the publish path is configured
         run: |
           set -euo pipefail
@@ -83,6 +82,7 @@ jobs:
           [ -n "${BUCKET}" ] || missing+=("AWS_UPDATE_S3_BUCKET")
           [ -n "${ARTIFACTS_URL}" ] || missing+=("WSO2_UPDATE_ARTIFACTS_URL (components must be mirrored; clients refuse upstream hosts)")
           [ -n "${COSIGN_PRIVATE_KEY}" ] || missing+=("COSIGN_PRIVATE_KEY")
+          [ -n "${WSO2_UPDATE_PUBLIC_KEY}" ] || missing+=("WSO2_UPDATE_PUBLIC_KEY (nothing would prove the signature matches the key released clients pin)")
           if [ ${#missing[@]} -gt 0 ]; then
             printf '::error::missing required secret: %s\n' "${missing[@]}" >&2
             exit 1
@@ -90,6 +90,7 @@ jobs:
           echo "publish path configured for channel ${CHANNEL}"
         env:
           COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+          WSO2_UPDATE_PUBLIC_KEY: ${{ secrets.WSO2_UPDATE_PUBLIC_KEY }}
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -322,7 +323,7 @@ jobs:
       # is what proves the two are the same pair — a mismatch rejects every artifact, on the user's
       # machine, after release.
       - name: Check the pinned key matches the signing key
-        if: ${{ !inputs.dry_run && env.HAS_PINNED_KEY == 'true' }}
+        if: ${{ !inputs.dry_run }}
         env:
           WSO2_UPDATE_PUBLIC_KEY: ${{ secrets.WSO2_UPDATE_PUBLIC_KEY }}
         run: |

--- a/.github/workflows/publish-components.yml
+++ b/.github/workflows/publish-components.yml
@@ -74,7 +74,7 @@ jobs:
       # A step `if:` cannot see `secrets`, so presence is hoisted to job env.
       HAS_PINNED_KEY: ${{ secrets.WSO2_UPDATE_PUBLIC_KEY != '' }}
     steps:
-      # Checked before the build rather than after it. All four are required: without mirroring or
+      # Checked before the build rather than after it. All three are required: without mirroring or
       # signing, the resulting document is one every client rejects.
       - name: Check the publish path is configured
         run: |
@@ -83,7 +83,6 @@ jobs:
           [ -n "${BUCKET}" ] || missing+=("AWS_UPDATE_S3_BUCKET")
           [ -n "${ARTIFACTS_URL}" ] || missing+=("WSO2_UPDATE_ARTIFACTS_URL (components must be mirrored; clients refuse upstream hosts)")
           [ -n "${COSIGN_PRIVATE_KEY}" ] || missing+=("COSIGN_PRIVATE_KEY")
-          [ -n "${COSIGN_PUBLIC_KEY}" ] || missing+=("COSIGN_PUBLIC_KEY")
           if [ ${#missing[@]} -gt 0 ]; then
             printf '::error::missing required secret: %s\n' "${missing[@]}" >&2
             exit 1
@@ -91,7 +90,6 @@ jobs:
           echo "publish path configured for channel ${CHANNEL}"
         env:
           COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
-          COSIGN_PUBLIC_KEY: ${{ secrets.COSIGN_PUBLIC_KEY }}
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -306,28 +304,41 @@ jobs:
         if: ${{ !inputs.dry_run }}
         uses: sigstore/cosign-installer@v3
 
+      # Derived from the signing key, not configured separately: a second public-key secret could
+      # only agree or disagree with this one, and a disagreement still verified in-run.
+      - name: Derive the signing public key
+        if: ${{ !inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          cosign public-key --key env://COSIGN_PRIVATE_KEY > signing.pub
+          grep -q 'BEGIN PUBLIC KEY' signing.pub
+          echo "derived the public half of COSIGN_PRIVATE_KEY"
+        env:
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+
       # Clients verify against WSO2_UPDATE_PUBLIC_KEY baked into product.json; CI signs with
-      # COSIGN_PRIVATE_KEY. Nothing else compares them, and a mismatch rejects every artifact.
+      # COSIGN_PRIVATE_KEY. Comparing the pinned key against the key DERIVED from the private one
+      # is what proves the two are the same pair — a mismatch rejects every artifact, on the user's
+      # machine, after release.
       - name: Check the pinned key matches the signing key
         if: ${{ !inputs.dry_run && env.HAS_PINNED_KEY == 'true' }}
         env:
           WSO2_UPDATE_PUBLIC_KEY: ${{ secrets.WSO2_UPDATE_PUBLIC_KEY }}
-          COSIGN_PUBLIC_KEY: ${{ secrets.COSIGN_PUBLIC_KEY }}
         run: |
           set -euo pipefail
           printf '%s' "$WSO2_UPDATE_PUBLIC_KEY" | base64 -d > pinned.pem 2>/dev/null || {
-            echo "::error::WSO2_UPDATE_PUBLIC_KEY is not valid base64. It must be 'base64 < cosign.pub'." >&2
+            echo "::error::WSO2_UPDATE_PUBLIC_KEY is not valid base64. It must be 'base64 -w0 < cosign.pub'." >&2
             exit 1
           }
-          printf '%s' "$COSIGN_PUBLIC_KEY" > signing.pem
           openssl pkey -pubin -in pinned.pem  -outform DER -out pinned.der
-          openssl pkey -pubin -in signing.pem -outform DER -out signing.der
+          openssl pkey -pubin -in signing.pub -outform DER -out signing.der
           if ! cmp -s pinned.der signing.der; then
-            echo "::error::WSO2_UPDATE_PUBLIC_KEY does not match COSIGN_PUBLIC_KEY. Clients would reject every artifact this run signs." >&2
+            echo "::error::WSO2_UPDATE_PUBLIC_KEY is not the public half of COSIGN_PRIVATE_KEY. Clients would reject every artifact this run signs." >&2
             exit 1
           fi
           echo "Pinned client key matches the signing key."
-          rm -f pinned.pem signing.pem pinned.der signing.der
+          rm -f pinned.pem pinned.der signing.der
 
       - name: Sign source document
         if: ${{ !inputs.dry_run }}
@@ -338,12 +349,8 @@ jobs:
 
       - name: Verify source signature
         if: ${{ !inputs.dry_run }}
-        env:
-          COSIGN_PUBLIC_KEY: ${{ secrets.COSIGN_PUBLIC_KEY }}
         run: |
-          printf '%s' "$COSIGN_PUBLIC_KEY" > cosign.pub
-          cosign verify-blob --key cosign.pub --signature source.json.sig source.json
-          rm -f cosign.pub
+          cosign verify-blob --key signing.pub --signature source.json.sig source.json
 
       # Statements, not artifact bytes: signing bytes alone would let a document offer an old
       # artifact under a new version label. The statement binds id + version + sha256 + requires.
@@ -352,7 +359,6 @@ jobs:
         env:
           COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
-          COSIGN_PUBLIC_KEY: ${{ secrets.COSIGN_PUBLIC_KEY }}
         run: |
           set -euo pipefail
           if [ ! -d artifacts-mirror ]; then
@@ -365,13 +371,11 @@ jobs:
             echo "::error::no artifacts-mirror directory, but this document names artifacts the current one does not; it would point at URLs with no bytes behind them." >&2
             exit 1
           fi
-          printf '%s' "$COSIGN_PUBLIC_KEY" > cosign.pub
           find artifacts-mirror -type f -name '*.statement.json' -print0 | while IFS= read -r -d '' file; do
             cosign sign-blob --key env://COSIGN_PRIVATE_KEY "${file}" --output-signature "${file}.sig" --yes
-            cosign verify-blob --key cosign.pub --signature "${file}.sig" "${file}"
+            cosign verify-blob --key signing.pub --signature "${file}.sig" "${file}"
             echo "signed $(basename "${file}")"
           done
-          rm -f cosign.pub
           artifacts=$(find artifacts-mirror -type f ! -name '*.statement.json' ! -name '*.sig' | wc -l | tr -d ' ')
           statements=$(find artifacts-mirror -type f -name '*.statement.json' | wc -l | tr -d ' ')
           echo "artifacts=${artifacts} statements=${statements}"

--- a/.github/workflows/publish-components.yml
+++ b/.github/workflows/publish-components.yml
@@ -332,6 +332,12 @@ jobs:
             echo "::error::WSO2_UPDATE_PUBLIC_KEY is not valid base64. It must be 'base64 -w0 < cosign.pub'." >&2
             exit 1
           }
+          # base64 -d accepts the empty string, so an empty secret would otherwise reach openssl
+          # and die there with an opaque parse error instead of this one.
+          [ -s pinned.pem ] || {
+            echo "::error::WSO2_UPDATE_PUBLIC_KEY decoded to nothing." >&2
+            exit 1
+          }
           openssl pkey -pubin -in pinned.pem  -outform DER -out pinned.der
           openssl pkey -pubin -in signing.pub -outform DER -out signing.der
           if ! cmp -s pinned.der signing.der; then


### PR DESCRIPTION
Backport of #2327 to `staging/5.1.0`. Five commits, cherry-picked from `e3e67f5`, `68e50fb`,
`6c93a4c`, `f4fc335` and `17bc1dd` with no conflicts, in their original order.

## Why

#2384 and #2385 backported the component-update mechanism (#2247, #2248) to this branch, but the CI
fixes that landed on `main` afterwards were not part of either PR. `build.yml` on this branch is
therefore #2248's original, and a `workflow_dispatch` started on `staging/5.1.0` runs it.

That is already failing. In
[run 34251747457](https://github.com/wso2/product-integrator/actions/runs/34251747457/job/102159470699)
the macOS job fails at `Publish Squirrel.Mac update payload to update bucket`:

```
upload failed: installers/mac/wso2-integrator-5.1.0-202609081633-arm64-mac.zip
  to s3://***/artifacts/app/.../wso2-integrator-...-arm64-mac.zip
  Unable to locate credentials
```

The step's gate on this branch is `env.HAS_AWS == 'true'`, which is only
`secrets.AWS_ACCESS_KEY_ID != ''` — the secret exists, so the gate opens — but the key is never put
in the step's environment. It also omits `publish_update_source` from its condition, so it runs on a
nightly that publishes nothing. The direct fix for that specific step is in #2328, which is stacked
on this PR; this one carries the preflight work it builds on.

The macOS job did not fail before #2385 only because `installers/mac/build.sh` on this branch
ignored `INSTALLER_PROFILE`, so no `-mac.zip` was produced and the upload path was inert.

## What this contains

- `e3e67f5` — derive the signing public key from the signing key instead of configuring it twice.
- `68e50fb` — require the pinned client key on any run that publishes updates.
- `6c93a4c` — don't fail the preflight on runs that would not publish.
- `f4fc335` — compare the pinned key against the signing key before the builds run, so a mismatch
  fails in seconds rather than surfacing as every client rejecting every artifact after release.
- `17bc1dd` — require the update-bucket credentials in the publish preflight.

Net effect on `build.yml`: three new steps in `resolve-versions` (`Check the publish path is
configured`, `cosign-installer`, `Verify the pinned client key matches the signing key`), all gated
on `publish_update_source && build_packed_installers && publish_tag != ''`, and the
`HAS_PINNED_KEY` scaffolding they replace is removed.

## Scope

Only `.github/workflows/build.yml` and `.github/workflows/publish-components.yml`. No installer
scripts, no product code.

**The scheduled nightly is not affected either way** — a `schedule` trigger reads `build.yml` from
the default branch. This matters for `workflow_dispatch` runs started on `staging/5.1.0`, and for
this branch being able to cut a release.

## Verification

- All five cherry-picks applied with 0 conflicts, in their original order.
- With #2328's backport on top, `build.yml` and `publish-components.yml` on this branch are
  **byte-identical to `main`**, and no `HAS_AWS` or `HAS_INSTALLER_BUCKET` scaffolding remains.
- Both workflow files parse.

**Not verified:** no CI run has exercised this branch. The check worth running before merge is a
`daily-build.yml` dispatch on this branch with `build_branch=builds/nightly-test` and
`publish_tag=nightly-test`, which reproduces the failing route without touching production.

## Part 1 of 2

#2328's backport is stacked on this branch and must merge after it.
