### PR TITLE
[staging/5.1.0] Drop the retired installer bucket and scope the update-bucket credentials

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -357,11 +357,6 @@ jobs:
     name: Build (macOS)
     runs-on: ${{ matrix.runner }}
     needs: [resolve-versions, compile]
-    env:
-      # secrets can't be referenced from a step `if:`, so their presence is hoisted here. Both are
-      # needed to publish the Squirrel.Mac payload: credentials to write, and a bucket to write to.
-      HAS_AWS: ${{ secrets.AWS_ACCESS_KEY_ID != '' }}
-      HAS_UPDATE_BUCKET: ${{ secrets.AWS_UPDATE_S3_BUCKET != '' }}
     defaults:
       run:
         working-directory: lib/vscode
@@ -829,31 +824,41 @@ jobs:
             xcrun stapler staple "$ARTIFACT"
           done
 
-      # Only the two steps below touch AWS in this job, and only on a publishing release, so the
-      # credentials are configured immediately before the upload rather than for the whole job.
-      - name: Configure AWS credentials for the update bucket
-        if: ${{ inputs.publish_update_source == true && inputs.build_packed_installers == true && env.HAS_AWS == 'true' && env.HAS_UPDATE_BUCKET == 'true' }}
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION || 'us-east-1' }}
-
+      # This is the only AWS consumer in the job, so the credentials go in its own `env:` rather
+      # than through configure-aws-credentials, which writes them to $GITHUB_ENV and would leave
+      # live S3 write credentials in scope for every step that follows.
+      #
+      # It fails rather than skips on a half-configured run: publish-update-source embeds
+      # app.squirrel.url into the darwin manifest regardless, so skipping here would ship a
+      # manifest pointing at an object nobody uploaded — a 404 for every macOS client at apply
+      # time, from a green build.
       - name: Publish Squirrel.Mac update payload to update bucket
-        if: ${{ inputs.publish_update_source == true && inputs.build_packed_installers == true && env.HAS_AWS == 'true' && env.HAS_UPDATE_BUCKET == 'true' }}
+        if: ${{ inputs.publish_update_source == true && inputs.build_packed_installers == true }}
         working-directory: .
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION || 'us-east-1' }}
+          AWS_UPDATE_S3_BUCKET: ${{ secrets.AWS_UPDATE_S3_BUCKET }}
         run: |
+          set -euo pipefail
+          missing=()
+          [ -n "${AWS_UPDATE_S3_BUCKET}" ] || missing+=("AWS_UPDATE_S3_BUCKET")
+          [ -n "${AWS_ACCESS_KEY_ID}" ] || missing+=("AWS_ACCESS_KEY_ID")
+          [ -n "${AWS_SECRET_ACCESS_KEY}" ] || missing+=("AWS_SECRET_ACCESS_KEY")
+          if [ ${#missing[@]} -gt 0 ]; then
+            printf '::error::missing required secret: %s\n' "${missing[@]}" >&2
+            exit 1
+          fi
           V="${{ needs.resolve-versions.outputs.integrator_version }}"
           ZIP="installers/mac/wso2-integrator-${V}-${{ matrix.arch }}-mac.zip"
-          # The step only runs when this build publishes updates, so a missing payload is the
-          # failure it looks like rather than a deployment that simply uploads nothing.
           if [ ! -f "$ZIP" ]; then
-            echo "Squirrel.Mac payload not found at $ZIP" >&2
+            echo "::error::Squirrel.Mac payload not found at $ZIP" >&2
             exit 1
           fi
           # Same artifacts layout as everything else; the darwin manifest's app.squirrel.url
           # (embedded by generate-update-manifest.mjs) points at this exact versioned CDN URL.
-          DEST="s3://${{ secrets.AWS_UPDATE_S3_BUCKET }}/artifacts/app/${V}/"
+          DEST="s3://${AWS_UPDATE_S3_BUCKET}/artifacts/app/${V}/"
           aws s3 cp "$ZIP" "${DEST}wso2-integrator-${V}-${{ matrix.arch }}-mac.zip" --content-type application/zip --cache-control no-cache
           echo "Published Squirrel.Mac payload for darwin/${{ matrix.arch }} (v${V})"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -358,10 +358,10 @@ jobs:
     runs-on: ${{ matrix.runner }}
     needs: [resolve-versions, compile]
     env:
-      # secrets can't be referenced from a step `if:`. HAS_AWS says credentials exist;
-      # HAS_INSTALLER_BUCKET says a target bucket does. They are different secrets.
+      # secrets can't be referenced from a step `if:`, so their presence is hoisted here. Both are
+      # needed to publish the Squirrel.Mac payload: credentials to write, and a bucket to write to.
       HAS_AWS: ${{ secrets.AWS_ACCESS_KEY_ID != '' }}
-      HAS_INSTALLER_BUCKET: ${{ secrets.AWS_S3_BUCKET != '' }}
+      HAS_UPDATE_BUCKET: ${{ secrets.AWS_UPDATE_S3_BUCKET != '' }}
     defaults:
       run:
         working-directory: lib/vscode
@@ -828,18 +828,25 @@ jobs:
               --wait
             xcrun stapler staple "$ARTIFACT"
           done
+
+      # Only the two steps below touch AWS in this job, and only on a publishing release, so the
+      # credentials are configured immediately before the upload rather than for the whole job.
+      - name: Configure AWS credentials for the update bucket
+        if: ${{ inputs.publish_update_source == true && inputs.build_packed_installers == true && env.HAS_AWS == 'true' && env.HAS_UPDATE_BUCKET == 'true' }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION || 'us-east-1' }}
+
       - name: Publish Squirrel.Mac update payload to update bucket
-        if: ${{ inputs.build_packed_installers == true && env.HAS_AWS == 'true' }}
+        if: ${{ inputs.publish_update_source == true && inputs.build_packed_installers == true && env.HAS_AWS == 'true' && env.HAS_UPDATE_BUCKET == 'true' }}
         working-directory: .
         run: |
           V="${{ needs.resolve-versions.outputs.integrator_version }}"
           ZIP="installers/mac/wso2-integrator-${V}-${{ matrix.arch }}-mac.zip"
-          # Bucket first: a deployment that publishes no updates skips cleanly here, and only a
-          # deployment that WOULD upload treats a missing payload as the failure it is.
-          if [ -z "${{ secrets.AWS_UPDATE_S3_BUCKET }}" ]; then
-            echo "AWS_UPDATE_S3_BUCKET not set — skipping Squirrel.Mac payload upload."
-            exit 0
-          fi
+          # The step only runs when this build publishes updates, so a missing payload is the
+          # failure it looks like rather than a deployment that simply uploads nothing.
           if [ ! -f "$ZIP" ]; then
             echo "Squirrel.Mac payload not found at $ZIP" >&2
             exit 1
@@ -899,11 +906,6 @@ jobs:
     name: Build (Windows)
     runs-on: windows-2022
     needs: [resolve-versions, compile]
-    env:
-      # secrets can't be referenced from a step `if:`. HAS_AWS says credentials exist;
-      # HAS_INSTALLER_BUCKET says a target bucket does. They are different secrets.
-      HAS_AWS: ${{ secrets.AWS_ACCESS_KEY_ID != '' }}
-      HAS_INSTALLER_BUCKET: ${{ secrets.AWS_S3_BUCKET != '' }}
     defaults:
       run:
         working-directory: lib/vscode


### PR DESCRIPTION
Backport of #2328 to `staging/5.1.0`. Cherry-picked from `8b686da` and `a744490` with no conflicts,
and rebased onto `staging/5.1.0` now that #2394 (the #2327 backport this builds on) has merged.

## This is the fix for the failing macOS job

[Run 34251747457](https://github.com/wso2/product-integrator/actions/runs/34251747457/job/102159470699)
fails at `Publish Squirrel.Mac update payload to update bucket`:

```
upload failed: installers/mac/wso2-integrator-5.1.0-202609081633-arm64-mac.zip
  to s3://***/artifacts/app/.../wso2-integrator-...-arm64-mac.zip
  Unable to locate credentials
```

On this branch the step reads:

```yaml
if: ${{ inputs.build_packed_installers == true && env.HAS_AWS == 'true' }}
# no credentials in env:
run: aws s3 cp "$ZIP" "$DEST..."
```

`HAS_AWS` is `${{ secrets.AWS_ACCESS_KEY_ID != '' }}`, so it reports that credentials *exist*, opens
the gate, and then the step runs `aws s3 cp` without them in scope. Its condition also omits
`publish_update_source`, so it runs on a nightly that publishes nothing.

After this backport:

```yaml
if: ${{ inputs.publish_update_source == true && inputs.build_packed_installers == true }}
env:
  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
  AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION || 'us-east-1' }}
  AWS_UPDATE_S3_BUCKET: ${{ secrets.AWS_UPDATE_S3_BUCKET }}
```

The nightly skips the step outright, and a run that does publish carries the credentials in the
step's own environment rather than relying on an ambient login. It fails loudly on a
half-configured run rather than skipping, because `publish-update-source` embeds
`app.squirrel.url` into the darwin manifest regardless — skipping would ship a manifest pointing at
an object nobody uploaded.

## Why this only started failing now

The step was inert on this branch until #2385. `installers/mac/build.sh` ignored
`INSTALLER_PROFILE`, so no `-mac.zip` was produced and there was nothing to upload — which is why
macOS passed during the five nights Windows was failing. #2385 backported the mechanism, the zip is
now built, and the upload path went live carrying #2248's original credential handling.

## What this contains

- `8b686da` — drop the retired installer bucket (`AWS_S3_BUCKET`, `HAS_INSTALLER_BUCKET`) and
  restore the update-bucket login.
- `a744490` — scope the update-bucket credentials to the upload step, and fail on a half-configured
  release.

`HAS_AWS` and `HAS_INSTALLER_BUCKET` are removed by these two commits; nothing references them
afterwards.

## Scope

Only `.github/workflows/build.yml`. No installer scripts, no product code.

**The scheduled nightly is not affected either way** — a `schedule` trigger reads `build.yml` from
the default branch, where this step is already gated on `publish_update_source` and skipped. This
matters for `workflow_dispatch` runs started on `staging/5.1.0`, which is the run that failed.

## Verification

- Both cherry-picks applied with 0 conflicts.
- With #2394 merged and this on top, `build.yml` and `publish-components.yml` on this branch are
  **byte-identical to `main`**, and no `HAS_AWS` or `HAS_INSTALLER_BUCKET` scaffolding remains.
- `build.yml` parses.

**Not verified:** no CI run has exercised this branch. Re-dispatching `daily-build.yml` on
`staging/5.1.0` with `build_branch=builds/nightly-test` and `publish_tag=nightly-test` reproduces
the failing route without touching production, and is the check worth running before merge.
