### PR TITLE
Add project explorer icon handling support

### DIFF
--- a/wi/wi-extension/src/bi/project-explorer/project-explorer-provider.ts
+++ b/wi/wi-extension/src/bi/project-explorer/project-explorer-provider.ts
@@ -58,7 +58,9 @@ export class ProjectExplorerEntry extends vscode.TreeItem {
         this.tooltip = `${this.label}`;
         this.info = info;
         this.position = position;
-        if (iconLight && iconDark) {
+        if (icon && isCodicon) {
+            this.iconPath = new vscode.ThemeIcon(icon, iconColor);
+        } else if (iconLight && iconDark) {
             const tint = (svg: string) => iconSvgColor
                 ? svg.replace(/((?:fill|stroke)\s*=\s*["'])(currentColor|black|white|#000(?:000)?|#fff(?:fff)?)(["'])/gi,
                     `$1${iconSvgColor}$3`)
@@ -67,8 +69,6 @@ export class ProjectExplorerEntry extends vscode.TreeItem {
                 light: vscode.Uri.parse(`data:image/svg+xml;base64,${Buffer.from(tint(iconLight)).toString('base64')}`),
                 dark: vscode.Uri.parse(`data:image/svg+xml;base64,${Buffer.from(tint(iconDark)).toString('base64')}`)
             };
-        } else if (icon && isCodicon) {
-            this.iconPath = new vscode.ThemeIcon(icon, iconColor);
         } else if (icon) {
             // Load icon from WI extension's assets folder
             const extensionPath = ext.context.extensionPath;

--- a/wi/wi-extension/src/bi/project-explorer/project-explorer-provider.ts
+++ b/wi/wi-extension/src/bi/project-explorer/project-explorer-provider.ts
@@ -49,13 +49,25 @@ export class ProjectExplorerEntry extends vscode.TreeItem {
         icon: string = 'folder',
         isCodicon: boolean = false,
         position: NodePosition | undefined = undefined,
-        iconColor: vscode.ThemeColor | undefined = undefined
+        iconColor: vscode.ThemeColor | undefined = undefined,
+        iconLight?: string,
+        iconDark?: string,
+        iconSvgColor?: string
     ) {
         super(label, collapsibleState);
         this.tooltip = `${this.label}`;
         this.info = info;
         this.position = position;
-        if (icon && isCodicon) {
+        if (iconLight && iconDark) {
+            const tint = (svg: string) => iconSvgColor
+                ? svg.replace(/((?:fill|stroke)\s*=\s*["'])(currentColor|black|white|#000(?:000)?|#fff(?:fff)?)(["'])/gi,
+                    `$1${iconSvgColor}$3`)
+                : svg;
+            this.iconPath = {
+                light: vscode.Uri.parse(`data:image/svg+xml;base64,${Buffer.from(tint(iconLight)).toString('base64')}`),
+                dark: vscode.Uri.parse(`data:image/svg+xml;base64,${Buffer.from(tint(iconDark)).toString('base64')}`)
+            };
+        } else if (icon && isCodicon) {
             this.iconPath = new vscode.ThemeIcon(icon, iconColor);
         } else if (icon) {
             // Load icon from WI extension's assets folder
@@ -551,7 +563,10 @@ function getComponents(
             itemType === DIRECTORY_MAP.AGENT_DEFINITION ? 'symbol-class' : comp.icon,
             itemType === DIRECTORY_MAP.AGENT_DEFINITION,
             comp.position,
-            itemType === DIRECTORY_MAP.AGENT_DEFINITION ? new vscode.ThemeColor('icon.foreground') : undefined
+            itemType === DIRECTORY_MAP.AGENT_DEFINITION ? new vscode.ThemeColor('icon.foreground') : undefined,
+            comp.iconLight,
+            comp.iconDark,
+            comp.iconColor
         );
         fileEntry.resourceUri = Uri.parse(`bi-category:${projectPath}`);
         fileEntry.command = {

--- a/wi/wi-extension/src/bi/types.ts
+++ b/wi/wi-extension/src/bi/types.ts
@@ -83,6 +83,9 @@ export interface ProjectStructureArtifactResponse {
     type: DIRECTORY_MAP;
     path: string;
     icon: string;
+    iconColor?: string;
+    iconLight?: string;
+    iconDark?: string;
     position?: NodePosition;
     context?: string;
     resources?: ProjectStructureArtifactResponse[];


### PR DESCRIPTION
## Purpose
$subject

Fixes https://github.com/wso2/product-integrator/issues/2423

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Project Explorer artifact entries can now display custom light- and dark-theme SVG icons.
  - Custom icon colors are supported, improving visual consistency across themes.
  - Icons are rendered directly when available, providing more accurate artifact identification.

- **Chores**
  - Updated the ICP component version to the latest alpha2 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->